### PR TITLE
feat: port stroke data structures to js

### DIFF
--- a/js/ControlPoint.js
+++ b/js/ControlPoint.js
@@ -1,0 +1,12 @@
+import { Vector3, Quaternion } from 'three';
+
+export class ControlPoint {
+  constructor(pos = new Vector3(), orient = new Quaternion(), pressure = 0, timestampMs = 0) {
+    this.pos = pos;
+    this.orient = orient;
+    this.pressure = pressure;
+    this.timestampMs = timestampMs;
+  }
+}
+
+export default ControlPoint;

--- a/js/HSLColor.js
+++ b/js/HSLColor.js
@@ -1,0 +1,121 @@
+import { Color } from 'three';
+
+function colorCalc(c, t1, t2) {
+  if (c < 0) {
+    c += 6;
+  } else if (c >= 6) {
+    c -= 6;
+  }
+  if (c < 1) return t1 + (t2 - t1) * c;
+  if (c < 3) return t2;
+  if (c < 4) return t1 + (t2 - t1) * (4 - c);
+  return t1;
+}
+
+export class HSLColor {
+  static HUE_MAX = 6;
+
+  constructor(h = 0, s = 0, l = 0, a = 1) {
+    h = h % HSLColor.HUE_MAX;
+    if (h < 0) h += HSLColor.HUE_MAX;
+    this.h = h;
+    this.s = s;
+    this.l = l;
+    this.a = a;
+  }
+
+  get hueDegrees() {
+    return this.h * (360 / HSLColor.HUE_MAX);
+  }
+
+  set hueDegrees(value) {
+    value = ((value * HSLColor.HUE_MAX) / 360) % HSLColor.HUE_MAX;
+    if (value < 0) value += HSLColor.HUE_MAX;
+    this.h = value;
+  }
+
+  get hue01() {
+    return this.h * (1 / HSLColor.HUE_MAX);
+  }
+
+  set hue01(value) {
+    value = (value * HSLColor.HUE_MAX) % HSLColor.HUE_MAX;
+    if (value < 0) value += HSLColor.HUE_MAX;
+    this.h = value;
+  }
+
+  toColor() {
+    if (this.s === 0) {
+      const gray = new Color(this.l, this.l, this.l);
+      return { color: gray, a: this.a };
+    }
+    let t2;
+    if (this.l < 0.5) {
+      t2 = this.l * (1 + this.s);
+    } else {
+      t2 = this.l + this.s - this.l * this.s;
+    }
+    const t1 = 2 * this.l - t2;
+    const th = this.h * (6 / HSLColor.HUE_MAX);
+    const tr = th + 2;
+    const tg = th;
+    const tb = th - 2;
+    const color = new Color(
+      colorCalc(tr, t1, t2),
+      colorCalc(tg, t1, t2),
+      colorCalc(tb, t1, t2)
+    );
+    return { color, a: this.a };
+  }
+
+  static fromColor(color, a = 1) {
+    const r = color.r;
+    const g = color.g;
+    const b = color.b;
+    const min = Math.min(r, g, b);
+    const max = Math.max(r, g, b);
+    const delta = max - min;
+    let h = 0;
+    let s = 0;
+    const l = (max + min) * 0.5;
+    if (delta !== 0) {
+      if (l < 0.5) {
+        s = delta / (max + min);
+      } else {
+        s = delta / (2 - max - min);
+      }
+      if (r === max) {
+        h = (g - b) / delta;
+      } else if (g === max) {
+        h = 2 + (b - r) / delta;
+      } else {
+        h = 4 + (r - g) / delta;
+      }
+    }
+    h *= HSLColor.HUE_MAX / 6;
+    return new HSLColor(h, s, l, a);
+  }
+
+  static fromHSV(h, s, v, a = 1) {
+    h = h % HSLColor.HUE_MAX;
+    if (h < 0) h += HSLColor.HUE_MAX;
+    const l = v - 0.5 * s * v;
+    let s2;
+    if (l <= 0.5) {
+      s2 = s / (2 - s);
+    } else {
+      s2 = (s * v) / (2 * (1 - v) + s * v);
+    }
+    return new HSLColor(h, s2, l, a);
+  }
+
+  getBaseColor() {
+    return new HSLColor(this.h, this.s, 0.5, this.a);
+  }
+
+  toString() {
+    return `HSLA(${this.h.toFixed(3)}, ${this.s.toFixed(3)}, ${this.l.toFixed(3)}, ${this.a.toFixed(3)})`;
+  }
+}
+
+export default HSLColor;

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -1,9 +1,9 @@
 import {
   Scene,
   Group,
-  BufferGeometry,
-  LineBasicMaterial,
-  LineLoop,
+  Mesh,
+  MeshBasicMaterial,
+  DoubleSide,
   Vector3,
   Quaternion,
   Color,
@@ -12,6 +12,7 @@ import { pathToFileURL } from 'node:url';
 import { TrTransform } from './TrTransform.js';
 import { ControlPoint } from './ControlPoint.js';
 import { Stroke, StrokeType } from './Stroke.js';
+import { SimpleBrush } from './SimpleBrush.js';
 
 class Pointer {
   constructor(canvas) {
@@ -19,18 +20,17 @@ class Pointer {
   }
 
   recreateLineFromMemory(stroke) {
-    const points = stroke.controlPoints.map(cp => cp.pos);
-    const geometry = new BufferGeometry().setFromPoints(points);
-    const material = new LineBasicMaterial({ color: stroke.color });
-    const line = new LineLoop(geometry, material);
-    this.canvas.add(line);
+    const geometry = SimpleBrush.buildGeometry(stroke.controlPoints, stroke.brushSize);
+    const material = new MeshBasicMaterial({ color: stroke.color, side: DoubleSide });
+    const mesh = new Mesh(geometry, material);
+    this.canvas.add(mesh);
     stroke.object = {
       canvas: this.canvas,
       hideBrush: hide => {
-        line.visible = !hide;
+        mesh.visible = !hide;
       },
       setParent: parent => {
-        parent.add(line);
+        parent.add(mesh);
         this.canvas = parent;
       },
     };

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -1,0 +1,88 @@
+import {
+  Scene,
+  Group,
+  BufferGeometry,
+  LineBasicMaterial,
+  LineLoop,
+  Vector3,
+  Quaternion,
+  Color,
+} from 'three';
+import { pathToFileURL } from 'node:url';
+import { TrTransform } from './TrTransform.js';
+import { ControlPoint } from './ControlPoint.js';
+import { Stroke, StrokeType } from './Stroke.js';
+
+class Pointer {
+  constructor(canvas) {
+    this.canvas = canvas;
+  }
+
+  recreateLineFromMemory(stroke) {
+    const points = stroke.controlPoints.map(cp => cp.pos);
+    const geometry = new BufferGeometry().setFromPoints(points);
+    const material = new LineBasicMaterial({ color: stroke.color });
+    const line = new LineLoop(geometry, material);
+    this.canvas.add(line);
+    stroke.object = {
+      canvas: this.canvas,
+      hideBrush: hide => {
+        line.visible = !hide;
+      },
+      setParent: parent => {
+        parent.add(line);
+        this.canvas = parent;
+      },
+    };
+    stroke.type = StrokeType.BrushStroke;
+  }
+}
+
+export function drawCircle() {
+  const scene = new Scene();
+  const canvas = new Group();
+  scene.add(canvas);
+
+  const pointer = new Pointer(canvas);
+
+  const path = [];
+  const segments = 32;
+  const radius = 1.5;
+  for (let i = 0; i < segments; i++) {
+    const angle = (i * 2 * Math.PI) / segments;
+    const position = new Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
+    const rotation = new Quaternion().setFromAxisAngle(new Vector3(0, 0, 1), angle);
+    path.push(TrTransform.TRS(position, rotation, 1));
+  }
+
+  const controlPoints = [];
+  let time = 0;
+  for (const tr of path) {
+    const cp = new ControlPoint(
+      tr.translation.clone(),
+      tr.rotation.clone(),
+      tr.scale,
+      time++
+    );
+    controlPoints.push(cp);
+  }
+
+  const stroke = new Stroke();
+  stroke.intendedCanvas = canvas;
+  stroke.brushGuid = 'default';
+  stroke.brushScale = 1;
+  stroke.brushSize = 1;
+  stroke.color = new Color('blue');
+  stroke.seed = 0;
+  stroke.controlPoints = controlPoints;
+  stroke.controlPointsToDrop = new Array(controlPoints.length).fill(false);
+
+  stroke.recreate(pointer, TrTransform.identity, canvas);
+
+  console.log(`Created stroke with ${controlPoints.length} control points.`);
+  console.log(`Canvas has ${canvas.children.length} object(s).`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  drawCircle();
+}

--- a/js/QuaternionExtensions.js
+++ b/js/QuaternionExtensions.js
@@ -1,0 +1,85 @@
+import { Quaternion, Vector3 } from 'three';
+
+/**
+ * Utilities mirroring Tilt Brush's QuaternionExtensions.
+ */
+export default class QuaternionExtensions {
+  /**
+   * Creates a quaternion rotating by `angle` radians around `axis`.
+   */
+  static angleAxisRad(angle, axis) {
+    const q = new Quaternion();
+    q.setFromAxisAngle(axis, angle);
+    return q;
+  }
+
+  /**
+   * Quaternion logarithm; returns a quaternion whose xyz represent half-angle.
+   * The input must be unit-length.
+   */
+  static log(q) {
+    const vecLenSq = q.x * q.x + q.y * q.y + q.z * q.z;
+    const lenSq = vecLenSq + q.w * q.w;
+    if (Math.abs(lenSq - 1) > 3e-3) {
+      throw new Error('Quaternion must be unit');
+    }
+
+    const sinTheta = Math.sqrt(vecLenSq);
+    const theta = Math.atan2(sinTheta, q.w);
+
+    if (sinTheta < 1e-5) {
+      if (q.w > 0) {
+        return new Quaternion(q.x, q.y, q.z, 0);
+      }
+      const axis = new Vector3(q.x, q.y, q.z).normalize();
+      if (axis.lengthSq() === 0) axis.set(0, 1, 0);
+      axis.multiplyScalar(theta);
+      return new Quaternion(axis.x, axis.y, axis.z, 0);
+    } else {
+      const k = theta / sinTheta;
+      return new Quaternion(k * q.x, k * q.y, k * q.z, 0);
+    }
+  }
+
+  /**
+   * Quaternion exponentiation; input must have w === 0.
+   */
+  static exp(q) {
+    if (q.w !== 0) {
+      throw new Error('Quaternion must be pure (w=0)');
+    }
+    const v = new Vector3(q.x, q.y, q.z);
+    const vLen = v.length();
+    let sinVOverV;
+    if (vLen < 1e-4) {
+      sinVOverV = vLen;
+    } else {
+      sinVOverV = Math.sin(vLen) / vLen;
+    }
+
+    v.multiplyScalar(sinVOverV);
+    return new Quaternion(v.x, v.y, v.z, Math.cos(vLen));
+  }
+
+  /**
+   * Returns the negated quaternion.
+   */
+  static negated(q) {
+    return new Quaternion(-q.x, -q.y, -q.z, -q.w);
+  }
+
+  /**
+   * Returns the imaginary component of the quaternion.
+   */
+  static im(q) {
+    return new Vector3(q.x, q.y, q.z);
+  }
+
+  /**
+   * Returns the inverse without assuming unit-length.
+   */
+  static trueInverse(q) {
+    const f = 1 / q.lengthSq();
+    return new Quaternion(-q.x * f, -q.y * f, -q.z * f, q.w * f);
+  }
+}

--- a/js/SimpleBrush.js
+++ b/js/SimpleBrush.js
@@ -1,0 +1,51 @@
+import { BufferGeometry, Float32BufferAttribute, Vector3 } from 'three';
+
+/**
+ * Very small brush geometry builder that extrudes a ribbon from control points.
+ * This is a placeholder for full Tilt Brush brush implementations.
+ */
+export class SimpleBrush {
+  /**
+   * Build a ribbon mesh from control points.
+   * @param {ControlPoint[]} controlPoints
+   * @param {number} size Brush diameter
+   * @returns {BufferGeometry}
+   */
+  static buildGeometry(controlPoints, size = 1) {
+    if (!controlPoints || controlPoints.length < 2) {
+      return new BufferGeometry();
+    }
+
+    const positions = [];
+    const uvs = [];
+    const indices = [];
+    const half = size / 2;
+
+    for (let i = 0; i < controlPoints.length; i++) {
+      const cp = controlPoints[i];
+      // Use orientation's X axis as the brush's right vector
+      const right = new Vector3(1, 0, 0).applyQuaternion(cp.orient).multiplyScalar(half);
+      const v0 = cp.pos.clone().add(right);
+      const v1 = cp.pos.clone().sub(right);
+
+      positions.push(v0.x, v0.y, v0.z, v1.x, v1.y, v1.z);
+      const t = i / (controlPoints.length - 1);
+      uvs.push(0, t, 1, t);
+
+      if (i > 0) {
+        const base = i * 2;
+        indices.push(base - 2, base - 1, base);
+        indices.push(base, base - 1, base + 1);
+      }
+    }
+
+    const geom = new BufferGeometry();
+    geom.setAttribute('position', new Float32BufferAttribute(positions, 3));
+    geom.setAttribute('uv', new Float32BufferAttribute(uvs, 2));
+    geom.setIndex(indices);
+    geom.computeVertexNormals();
+    return geom;
+  }
+}
+
+export default SimpleBrush;

--- a/js/Stroke.js
+++ b/js/Stroke.js
@@ -1,0 +1,148 @@
+import { Vector3, Quaternion } from 'three';
+import { StrokeData } from './StrokeData.js';
+
+export const StrokeType = Object.freeze({
+  NotCreated: 0,
+  BrushStroke: 1,
+  BatchedBrushStroke: 2,
+});
+
+/**
+ * Port of Tilt Brush's Stroke class. Handles stroke metadata and basic
+ * transformation logic without any Unity-specific rendering code.
+ */
+export class Stroke extends StrokeData {
+  constructor(existing = null) {
+    super(existing);
+    this.type = StrokeType.NotCreated;
+    this.intendedCanvas = null;
+    this.object = null;
+    this.copyForSaveThread = null;
+    this.controlPointsToDrop = existing ? [...(existing.controlPointsToDrop || [])] : [];
+  }
+
+  get canvas() {
+    if (this.type === StrokeType.NotCreated) {
+      return this.intendedCanvas;
+    }
+    if (this.type === StrokeType.BrushStroke) {
+      return this.object ? this.object.canvas : null;
+    }
+    throw new Error('Invalid stroke type');
+  }
+
+  invalidateCopy() {
+    this.copyForSaveThread = null;
+  }
+
+  uncreate() {
+    this.intendedCanvas = this.canvas;
+    this.object = null;
+    this.type = StrokeType.NotCreated;
+  }
+
+  setParent(canvas) {
+    const prevCanvas = this.canvas;
+    if (prevCanvas === canvas) {
+      return;
+    }
+
+    if (this.type === StrokeType.BrushStroke && this.object && typeof this.object.setParent === 'function') {
+      this.object.setParent(canvas);
+    } else {
+      this.intendedCanvas = canvas;
+    }
+  }
+
+  /**
+   * Applies a left transform to all control points. The transform should be an
+   * object with { position: Vector3, rotation: Quaternion, scale: number }.
+   * The brushScale is updated by the transform and the cached copy is invalidated.
+   */
+  leftTransformControlPoints(transform, absoluteScale = false) {
+    let position, rotation, scale;
+    if (transform && transform.translation) {
+      position = transform.translation;
+      rotation = transform.rotation;
+      scale = transform.scale;
+    } else {
+      ({ position = new Vector3(), rotation = new Quaternion(), scale = 1 } = transform || {});
+    }
+    for (const cp of this.controlPoints) {
+      cp.pos.multiplyScalar(scale);
+      cp.pos.applyQuaternion(rotation);
+      cp.pos.add(position);
+      cp.orient.premultiply(rotation);
+    }
+    this.brushScale *= absoluteScale ? Math.abs(scale) : scale;
+    this.invalidateCopy();
+  }
+
+  // TODO: port matrix-based variant
+  leftTransformControlPointsMatrix(matrix) {
+    // TODO: implement using Matrix4 operations
+    throw new Error('leftTransformControlPointsMatrix not implemented');
+  }
+
+  /**
+   * Set the parent canvas while preserving world-space position.
+   * If leftTransform is provided, it will be applied to the control points.
+   * When geometry exists, the stroke is recreated through the provided pointer.
+   */
+  setParentKeepWorldPosition(canvas, pointer, leftTransform = null, absoluteScale = false) {
+    const prevCanvas = this.canvas;
+    if (prevCanvas === canvas) {
+      return;
+    }
+
+    const transform = leftTransform;
+    if (this.type === StrokeType.NotCreated || !transform) {
+      this.setParent(canvas);
+      if (transform) {
+        this.leftTransformControlPoints(transform, absoluteScale);
+      }
+    } else if (this.type === StrokeType.BrushStroke) {
+      this.uncreate();
+      this.intendedCanvas = canvas;
+      this.leftTransformControlPoints(transform, absoluteScale);
+      if (pointer && typeof pointer.recreateLineFromMemory === 'function') {
+        pointer.recreateLineFromMemory(this);
+      }
+    } else {
+      this.setParent(canvas);
+    }
+  }
+
+  /**
+   * Hide or show the stroke's geometry if possible.
+   */
+  hide(hide) {
+    if (this.type === StrokeType.BrushStroke && this.object && typeof this.object.hideBrush === 'function') {
+      this.object.hideBrush(hide);
+    } else if (this.type === StrokeType.NotCreated) {
+      console.error('Unexpected: NotCreated stroke');
+    }
+  }
+
+  // Placeholder for full recreate logic; only handles basic transform/parenting.
+  recreate(pointer, leftTransform = null, canvas = null, absoluteScale = false) {
+    if (leftTransform || this.type === StrokeType.NotCreated) {
+      this.uncreate();
+      if (canvas) {
+        this.setParent(canvas);
+      }
+      if (leftTransform) {
+        this.leftTransformControlPoints(leftTransform, absoluteScale);
+      }
+      if (pointer && typeof pointer.recreateLineFromMemory === 'function') {
+        pointer.recreateLineFromMemory(this);
+      }
+    } else if (canvas) {
+      this.setParent(canvas);
+    } else {
+      throw new Error('Nothing to do');
+    }
+  }
+}
+
+export default Stroke;

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -1,0 +1,31 @@
+import { Color } from 'three';
+import { randomUUID } from 'node:crypto';
+import { ControlPoint } from './ControlPoint.js';
+
+export class StrokeData {
+  constructor(existing = null) {
+    if (existing) {
+      this.color = existing.color?.clone ? existing.color.clone() : existing.color;
+      this.brushGuid = existing.brushGuid;
+      this.brushSize = existing.brushSize;
+      this.brushScale = existing.brushScale;
+      this.seed = existing.seed;
+      this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
+        cp.pos?.clone ? cp.pos.clone() : cp.pos,
+        cp.orient?.clone ? cp.orient.clone() : cp.orient,
+        cp.pressure,
+        cp.timestampMs
+      ));
+    } else {
+      this.color = new Color();
+      this.brushGuid = null;
+      this.brushSize = 0;
+      this.brushScale = 1;
+      this.seed = 0;
+      this.controlPoints = [];
+    }
+    this.guid = randomUUID();
+  }
+}
+
+export default StrokeData;

--- a/js/TrTransform.js
+++ b/js/TrTransform.js
@@ -1,0 +1,208 @@
+import { Vector3, Quaternion, Matrix4 } from 'three';
+import QuaternionExtensions from './QuaternionExtensions.js';
+
+/**
+ * Port of Tilt Brush's TrTransform struct.
+ * Represents translation, rotation, and uniform scale.
+ */
+export class TrTransform {
+  constructor(translation = new Vector3(), rotation = new Quaternion(), scale = 1) {
+    this.translation = translation;
+    this.rotation = rotation;
+    this.scale = scale;
+  }
+
+  static identity = TrTransform.TR(new Vector3(), new Quaternion());
+
+  // Methods analogous to Matrix4x4.TRS
+  static T(t) {
+    return new TrTransform(t, new Quaternion(), 1);
+  }
+
+  static RQuaternion(r) {
+    return new TrTransform(new Vector3(), r, 1);
+  }
+
+  static R(angle, axis) {
+    const q = new Quaternion().setFromAxisAngle(axis, angle);
+    return new TrTransform(new Vector3(), q, 1);
+  }
+
+  static S(s) {
+    return new TrTransform(new Vector3(), new Quaternion(), s);
+  }
+
+  static TR(t, r) {
+    return new TrTransform(t, r, 1);
+  }
+
+  static TRS(t, r, s) {
+    return new TrTransform(t, r, s);
+  }
+
+  static fromMatrix4(m) {
+    // TODO: decompose matrix; assumes uniform scale
+    const t = new Vector3();
+    const r = new Quaternion();
+    const s = new Vector3();
+    m.decompose(t, r, s);
+    return new TrTransform(t, r, s.x);
+  }
+
+  static fromTransform(xf) {
+    // TODO: Implement using three.js Object3D
+    throw new Error('fromTransform not implemented');
+  }
+
+  static fromLocalTransform(xf) {
+    // TODO: Implement using three.js Object3D
+    throw new Error('fromLocalTransform not implemented');
+  }
+
+  static invMul(a, b) {
+    const aInvRot = QuaternionExtensions.trueInverse(a.rotation);
+    const translation = b.translation
+      .clone()
+      .sub(a.translation)
+      .divideScalar(a.scale)
+      .applyQuaternion(aInvRot);
+    const rotation = aInvRot.clone().multiply(b.rotation);
+    const scale = b.scale / a.scale;
+    return TrTransform.TRS(translation, rotation, scale);
+  }
+
+  static lerp(a, b, t) {
+    const translation = a.translation.clone().lerp(b.translation, t);
+    const rotation = a.rotation.clone().slerp(b.rotation, t);
+    const scale = Math.exp(Math.log(a.scale) * (1 - t) + Math.log(b.scale) * t);
+    return new TrTransform(translation, rotation, scale);
+  }
+
+  multiplyPoint(p) {
+    return p
+      .clone()
+      .multiplyScalar(this.scale)
+      .applyQuaternion(this.rotation)
+      .add(this.translation);
+  }
+
+  multiplyVector(v) {
+    return v
+      .clone()
+      .multiplyScalar(this.scale)
+      .applyQuaternion(this.rotation);
+  }
+
+  multiplyBivector(v) {
+    return v
+      .clone()
+      .multiplyScalar(this.scale * this.scale)
+      .applyQuaternion(this.rotation);
+  }
+
+  multiplyNormal(v) {
+    return v.clone().applyQuaternion(this.rotation);
+  }
+
+  // TODO: implement plane transformation
+  multiplyPlane(plane) {
+    throw new Error('multiplyPlane not implemented');
+  }
+
+  mul(b) {
+    return TrTransform.TRS(
+      this.rotation.clone().multiply(b.translation.clone().multiplyScalar(this.scale)).add(this.translation),
+      this.rotation.clone().multiply(b.rotation),
+      this.scale * b.scale
+    );
+  }
+
+  static approximately(lhs, rhs) {
+    const sameTranslation = lhs.translation.equals(rhs.translation);
+    const sameRotation = lhs.rotation.equals(rhs.rotation);
+    const sameScale = Math.abs(lhs.scale - rhs.scale) <= Number.EPSILON;
+    return sameTranslation && sameRotation && sameScale;
+  }
+
+  get inverse() {
+    const rinv = QuaternionExtensions.trueInverse(this.rotation);
+    const invScale = 1 / this.scale;
+    const translation = this.translation
+      .clone()
+      .multiplyScalar(-invScale)
+      .applyQuaternion(rinv);
+    return TrTransform.TRS(translation, rinv, invScale);
+  }
+
+  forward() {
+    return new Vector3(0, 0, 1).applyQuaternion(this.rotation);
+  }
+
+  up() {
+    return new Vector3(0, 1, 0).applyQuaternion(this.rotation);
+  }
+
+  right() {
+    return new Vector3(1, 0, 0).applyQuaternion(this.rotation);
+  }
+
+  isFinite() {
+    return [
+      this.translation.x,
+      this.translation.y,
+      this.translation.z,
+      this.rotation.x,
+      this.rotation.y,
+      this.rotation.z,
+      this.rotation.w,
+      this.scale,
+    ].every(Number.isFinite);
+  }
+
+  toString() {
+    return `T: ${this.translation.x.toExponential()} ${this.translation.y.toExponential()} ${this.translation.z.toExponential()}\n` +
+      `R: ${this.rotation.x.toExponential()} ${this.rotation.y.toExponential()} ${this.rotation.z.toExponential()} ${this.rotation.w.toExponential()}\n` +
+      `S: ${this.scale.toExponential()}`;
+  }
+
+  equals(o) {
+    return (
+      o instanceof TrTransform &&
+      this.translation.equals(o.translation) &&
+      this.rotation.equals(o.rotation) &&
+      this.scale === o.scale
+    );
+  }
+
+  toMatrix4() {
+    const m = new Matrix4();
+    m.compose(
+      this.translation,
+      this.rotation,
+      new Vector3(this.scale, this.scale, this.scale)
+    );
+    return m;
+  }
+
+  toTransform(xf) {
+    // TODO: Implement using three.js Object3D
+    throw new Error('toTransform not implemented');
+  }
+
+  toLocalTransform(xf) {
+    // TODO: Implement using three.js Object3D
+    throw new Error('toLocalTransform not implemented');
+  }
+
+  transformBy(rhs) {
+    const similar = rhs.rotation.clone().multiply(this.rotation).multiply(QuaternionExtensions.trueInverse(rhs.rotation));
+    const retTrans = similar
+      .clone()
+      .multiply(rhs.translation.clone().multiplyScalar(-this.scale))
+      .add(rhs.rotation.clone().multiply(this.translation.clone().multiplyScalar(rhs.scale)))
+      .add(rhs.translation);
+    return new TrTransform(retTrans, similar, this.scale);
+  }
+}
+
+export default TrTransform;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "open-brush-stroke-gen-js",
+  "version": "1.0.0",
+  "description": "JavaScript utilities ported from Unity C# for three.js",
+  "type": "module",
+  "dependencies": {
+    "three": "^0.164.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add TrTransform class wrapping translation, rotation, and uniform scale with method stubs for unported features
- accept TrTransform in Stroke transforms and stub matrix-based variant
- add MinimalExample script that builds a circular stroke using Three.js and the new stroke classes

## Testing
- `npm install` *(fails: 403 403 Forbidden - GET https://registry.npmjs.org/three)*
- `node js/MinimalExample.js` *(fails: Cannot find package 'three' imported from js/MinimalExample.js)*

------
https://chatgpt.com/codex/tasks/task_e_689392e088408331b9352e375c9cf5c4