### PR TITLE
feat: scaffold brush infrastructure and remove simple helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Node.js dependencies
+node_modules/

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Minimal Stroke Example</title>
+  <style>
+    body { margin: 0; }
+    canvas { display: block; }
+  </style>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.156.1/build/three.module.js"
+      }
+    }
+  </script>
+</head>
+<body>
+  <script type="module">
+    import { Scene, PerspectiveCamera, WebGLRenderer } from 'three';
+    import { createCircleStroke } from './js/MinimalExample.js';
+
+    const renderer = new WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    const scene = new Scene();
+    createCircleStroke(scene);
+
+    const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.z = 5;
+
+    function animate() {
+      requestAnimationFrame(animate);
+      renderer.render(scene, camera);
+    }
+    animate();
+  </script>
+</body>
+</html>

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -17,6 +17,10 @@
   </script>
 </head>
 <body>
+  <select id="shape">
+    <option value="none">Round</option>
+    <option value="square" selected>Square</option>
+  </select>
   <script type="module">
     import { Scene, PerspectiveCamera, WebGLRenderer } from 'three';
     import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
@@ -27,7 +31,15 @@
     document.body.appendChild(renderer.domElement);
 
     const scene = new Scene();
-    createCircleStroke(scene);
+    const shapeSelect = document.getElementById('shape');
+    let current;
+
+    function rebuild() {
+      if (current) scene.remove(current.canvas);
+      current = createCircleStroke(scene, shapeSelect.value);
+    }
+    rebuild();
+    shapeSelect.addEventListener('change', rebuild);
 
     const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.z = 5;

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -10,7 +10,8 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "https://unpkg.com/three@0.156.1/build/three.module.js"
+        "three": "https://unpkg.com/three@0.156.1/build/three.module.js",
+        "three/addons/": "https://unpkg.com/three@0.156.1/examples/jsm/"
       }
     }
   </script>
@@ -18,6 +19,7 @@
 <body>
   <script type="module">
     import { Scene, PerspectiveCamera, WebGLRenderer } from 'three';
+    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
     import { createCircleStroke } from './js/MinimalExample.js';
 
     const renderer = new WebGLRenderer({ antialias: true });
@@ -30,8 +32,17 @@
     const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.z = 5;
 
+    const controls = new OrbitControls(camera, renderer.domElement);
+
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
     function animate() {
       requestAnimationFrame(animate);
+      controls.update();
       renderer.render(scene, camera);
     }
     animate();

--- a/js/BaseBrush.js
+++ b/js/BaseBrush.js
@@ -82,12 +82,21 @@ export class BaseBrush {
     // TODO: implement brush-specific initialization
   }
 
+  resetBrushForPreview(unusedXf) {
+    // TODO: reset brush state for preview rendering
+  }
+
   addControlPoint(cp, pointer, pressure, timestamp) {
     // TODO: handle control point addition
   }
 
   finalizeStroke() {
     // TODO: finalize stroke geometry
+  }
+
+  getSpawnInterval(pressure01) {
+    // TODO: return how far apart to spawn control points based on pressure
+    return 0;
   }
 }
 

--- a/js/BaseBrush.js
+++ b/js/BaseBrush.js
@@ -1,0 +1,94 @@
+import { Group, Color } from 'three';
+import { TrTransform } from './TrTransform.js';
+
+export class BaseBrush {
+  constructor(canBatch = false) {
+    this.m_bCanBatch = canBatch;
+    this.m_Desc = null;
+    this.m_EnableBackfaces = false;
+    this.m_PreviewMode = false;
+    this.m_IsLoading = false;
+    this.m_Color = new Color();
+    this.m_LastSpawnXf = TrTransform.identity;
+    this.m_BaseSize_PS = 0;
+    this.m_rng = { seed: 0 };
+    this.group = new Group();
+  }
+
+  static create(parent, xfInParentSpace, desc, color, size_PS) {
+    const brush = new BaseBrush();
+    brush.group.name = desc?.description || desc?.durableName || 'BrushStroke';
+    if (parent && parent.add) {
+      parent.add(brush.group);
+    }
+    brush.m_Desc = desc;
+    brush.m_Color.copy(color);
+    brush.m_BaseSize_PS = size_PS;
+    brush.m_LastSpawnXf = xfInParentSpace;
+    brush.initBrush(desc, xfInParentSpace);
+    return brush;
+  }
+
+  get StrokeScale() {
+    return this.m_LastSpawnXf.scale;
+  }
+
+  get LOCAL_TO_POINTER() {
+    return 1 / this.m_LastSpawnXf.scale;
+  }
+
+  get POINTER_TO_LOCAL() {
+    return this.m_LastSpawnXf.scale;
+  }
+
+  get BaseSize_PS() {
+    return this.m_BaseSize_PS;
+  }
+
+  set BaseSize_PS(v) {
+    this.m_BaseSize_PS = v;
+  }
+
+  get BaseSize_LS() {
+    return this.m_BaseSize_PS * this.POINTER_TO_LOCAL;
+  }
+
+  get Descriptor() {
+    return this.m_Desc;
+  }
+
+  get CurrentColor() {
+    return this.m_Color;
+  }
+
+  get RandomSeed() {
+    return this.m_rng.seed || 0;
+  }
+
+  set RandomSeed(value) {
+    this.m_rng.seed = value;
+  }
+
+  setIsLoading() {
+    this.m_IsLoading = true;
+  }
+
+  setPreviewMode() {
+    this.m_PreviewMode = true;
+  }
+
+  // Stub methods for subclasses to override
+  initBrush(desc, xfInParentSpace) {
+    // TODO: implement brush-specific initialization
+  }
+
+  addControlPoint(cp, pointer, pressure, timestamp) {
+    // TODO: handle control point addition
+  }
+
+  finalizeStroke() {
+    // TODO: finalize stroke geometry
+  }
+}
+
+export default BaseBrush;

--- a/js/BaseBrush.js
+++ b/js/BaseBrush.js
@@ -17,7 +17,7 @@ export class BaseBrush {
 
   static create(parent, xfInParentSpace, desc, color, size_PS) {
     const brush = new BaseBrush();
-    brush.group.name = desc?.description || desc?.durableName || 'BrushStroke';
+    brush.group.name = desc?.Description || desc?.m_DurableName || 'BrushStroke';
     if (parent && parent.add) {
       parent.add(brush.group);
     }

--- a/js/BrushCatalog.js
+++ b/js/BrushCatalog.js
@@ -1,0 +1,70 @@
+import BrushDescriptor from './BrushDescriptor.js';
+
+/**
+ * Port of Tilt Brush's BrushCatalog to manage brush descriptors and lookups.
+ * This minimal version registers descriptors and provides lookup utilities.
+ */
+export class BrushCatalog {
+  constructor() {
+    this.descriptors = new Map(); // guid -> BrushDescriptor
+    this.nameLookup = new Map(); // durableName/description -> guid
+  }
+
+  /**
+   * Register a new brush descriptor.
+   * @param {BrushDescriptor} desc
+   */
+  register(desc) {
+    this.descriptors.set(desc.guid, desc);
+    if (desc.durableName) this.nameLookup.set(desc.durableName, desc.guid);
+    if (desc.description) this.nameLookup.set(desc.description, desc.guid);
+  }
+
+  /**
+   * Retrieve a descriptor by guid.
+   * @param {string} guid
+   * @returns {BrushDescriptor|null}
+   */
+  getDescriptor(guid) {
+    return this.descriptors.get(guid) || null;
+  }
+
+  /**
+   * Retrieve a descriptor by name (durableName or description).
+   * @param {string} name
+   * @returns {BrushDescriptor|null}
+   */
+  getDescriptorByName(name) {
+    const guid = this.nameLookup.get(name);
+    return guid ? this.getDescriptor(guid) : null;
+  }
+
+  /**
+   * Return all registered descriptors.
+   * @returns {BrushDescriptor[]}
+   */
+  getAllDescriptors() {
+    return Array.from(this.descriptors.values());
+  }
+
+  // Stub: load descriptors from external source (e.g., JSON/Unity assets)
+  loadDescriptors(/* source */) {
+    // TODO: implement descriptor loading
+  }
+
+  // Stub: initialize catalog with default brushes
+  static createDefault() {
+    const catalog = new BrushCatalog();
+    // Default TubeBrush descriptor
+    catalog.register(
+      new BrushDescriptor({
+        guid: 'tube-brush',
+        durableName: 'TubeBrush',
+        description: 'Tube Brush',
+      })
+    );
+    return catalog;
+  }
+}
+
+export default BrushCatalog;

--- a/js/BrushCatalog.js
+++ b/js/BrushCatalog.js
@@ -1,70 +1,78 @@
+// Port of Tilt Brush's BrushCatalog to JavaScript.
+// Manages registration and lookup of BrushDescriptor instances.
 import BrushDescriptor from './BrushDescriptor.js';
 
-/**
- * Port of Tilt Brush's BrushCatalog to manage brush descriptors and lookups.
- * This minimal version registers descriptors and provides lookup utilities.
- */
-export class BrushCatalog {
-  constructor() {
-    this.descriptors = new Map(); // guid -> BrushDescriptor
-    this.nameLookup = new Map(); // durableName/description -> guid
+export default class BrushCatalog {
+  static m_GlobalNoiseTexture = null;
+  static m_GuidToBrush = new Map();
+  static m_GuiBrushList = [];
+  static m_Manifest = null;
+
+  static GetBrush(guid) {
+    return this.m_GuidToBrush.get(guid) || null;
   }
 
-  /**
-   * Register a new brush descriptor.
-   * @param {BrushDescriptor} desc
-   */
-  register(desc) {
-    this.descriptors.set(desc.guid, desc);
-    if (desc.durableName) this.nameLookup.set(desc.durableName, desc.guid);
-    if (desc.description) this.nameLookup.set(desc.description, desc.guid);
+  static Init(manifest) {
+    this.m_Manifest = manifest;
+    this.m_GuidToBrush = new Map();
+    this.m_GuiBrushList = [];
+
+    // TODO: Shader.SetGlobalTexture("_GlobalNoiseTexture", m_GlobalNoiseTexture);
+    const manifestBrushes = this.LoadBrushesInManifest();
+
+    for (const brush of manifestBrushes) {
+      const existing = this.m_GuidToBrush.get(brush.m_Guid);
+      if (existing && existing !== brush) {
+        console.error(`Guid collision: ${existing} ${brush}`);
+        continue;
+      }
+      this.m_GuidToBrush.set(brush.m_Guid, brush);
+    }
+
+    // Add reverse links and auto-add compat brushes
+    for (const brush of manifestBrushes) {
+      brush.m_SupersededBy = null;
+    }
+    for (const brush of manifestBrushes) {
+      const older = brush.m_Supersedes;
+      if (!older) continue;
+      if (!this.m_GuidToBrush.has(older.m_Guid)) {
+        this.m_GuidToBrush.set(older.m_Guid, older);
+        older.m_HiddenInGui = true;
+      }
+      if (older.m_SupersededBy && older.m_SupersededBy.name !== brush.name) {
+        console.warn(
+          `Unexpected: ${older.name} is superseded by both ${older.m_SupersededBy.name} and ${brush.name}`
+        );
+      } else {
+        older.m_SupersededBy = brush;
+      }
+    }
+
+    // Postprocess: put brushes into parse-friendly list
+    this.m_GuiBrushList = [];
+    for (const brush of this.m_GuidToBrush.values()) {
+      if (brush.m_HiddenInGui) continue;
+      this.m_GuiBrushList.push(brush);
+    }
   }
 
-  /**
-   * Retrieve a descriptor by guid.
-   * @param {string} guid
-   * @returns {BrushDescriptor|null}
-   */
-  getDescriptor(guid) {
-    return this.descriptors.get(guid) || null;
-  }
+  static LoadBrushesInManifest() {
+    const output = [];
+    if (!this.m_Manifest) return output;
+    const brushes = this.m_Manifest.Brushes || [];
+    for (const desc of brushes) {
+      if (desc) output.push(desc);
+    }
 
-  /**
-   * Retrieve a descriptor by name (durableName or description).
-   * @param {string} name
-   * @returns {BrushDescriptor|null}
-   */
-  getDescriptorByName(name) {
-    const guid = this.nameLookup.get(name);
-    return guid ? this.getDescriptor(guid) : null;
-  }
-
-  /**
-   * Return all registered descriptors.
-   * @returns {BrushDescriptor[]}
-   */
-  getAllDescriptors() {
-    return Array.from(this.descriptors.values());
-  }
-
-  // Stub: load descriptors from external source (e.g., JSON/Unity assets)
-  loadDescriptors(/* source */) {
-    // TODO: implement descriptor loading
-  }
-
-  // Stub: initialize catalog with default brushes
-  static createDefault() {
-    const catalog = new BrushCatalog();
-    // Default TubeBrush descriptor
-    catalog.register(
-      new BrushDescriptor({
-        guid: 'tube-brush',
-        durableName: 'TubeBrush',
-        description: 'Tube Brush',
-      })
-    );
-    return catalog;
+    const compat = this.m_Manifest.CompatibilityBrushes || [];
+    const hidden = compat.filter(desc => !brushes.includes(desc));
+    for (const desc of hidden) {
+      if (desc) {
+        desc.m_HiddenInGui = true;
+        output.push(desc);
+      }
+    }
+    return output;
   }
 }
-
-export default BrushCatalog;

--- a/js/BrushDescriptor.js
+++ b/js/BrushDescriptor.js
@@ -1,52 +1,83 @@
-export class BrushDescriptor {
-  constructor({
-    guid = '',
-    durableName = '',
-    description = '',
-    brushPrefab = null,
-    tags = ['default'],
-    nondeterministic = false,
-    supersedes = null,
-    looksIdentical = false,
-    hiddenInGui = false,
-    material = null,
-    textureAtlasV = 1,
-    tileRate = 1,
-    brushSizeRange = [0, 0],
-    pressureSizeRange = [0.1, 1],
-    sizeVariance = 0,
-    previewPressureSizeMin = 0.001,
-    pressureOpacityRange = [0, 1],
-    opacity = 1,
-  } = {}) {
-    this.guid = guid;
-    this.durableName = durableName;
-    this.description = description;
-    this.brushPrefab = brushPrefab;
-    this.tags = tags;
-    this.nondeterministic = nondeterministic;
-    this.supersedes = supersedes;
-    this.supersededBy = null;
-    this.looksIdentical = looksIdentical;
-    this.hiddenInGui = hiddenInGui;
-    this.material = material;
-    this.textureAtlasV = textureAtlasV;
-    this.tileRate = tileRate;
-    this.brushSizeRange = brushSizeRange;
-    this.pressureSizeRange = pressureSizeRange;
-    this.sizeVariance = sizeVariance;
-    this.previewPressureSizeMin = previewPressureSizeMin;
-    this.pressureOpacityRange = pressureOpacityRange;
-    this.opacity = opacity;
+// Port of Tilt Brush's BrushDescriptor ScriptableObject to JavaScript.
+// Fields mirror the C# version to aid in porting brush metadata.
+
+export default class BrushDescriptor {
+  constructor() {
+    // Identity
+    this.m_Guid = '';
+    this.m_DurableName = '';
+    this.m_CreationVersion = '';
+    this.m_ShaderVersion = '10.0';
+    this.m_BrushPrefab = null;
+    this.m_Tags = ['default'];
+    this.m_Nondeterministic = false;
+    this.m_Supersedes = null;
+    this.m_SupersededBy = null; // set during catalog init
+    this.m_LooksIdentical = false;
+
+    // GUI
+    this.m_ButtonTexture = null;
+    this.m_LocalizedDescription = null; // stub for Unity LocalizedString
+    this.m_DescriptionExtra = '';
+    this.m_HiddenInGui = false;
+
+    // Material
+    this.m_Material = null;
+    this.m_TextureAtlasV = 1;
+    this.m_TileRate = 1;
+
+    // Size
+    this.m_BrushSizeRange = [0, 0];
+    this.m_PressureSizeRange = [0.1, 1];
+    this.m_SizeVariance = 0;
+    this.m_PreviewPressureSizeMin = 0.001;
+
+    // Color
+    this.m_Opacity = 1;
+    this.m_PressureOpacityRange = [0, 1];
+    this.m_ColorLuminanceMin = 0;
+    this.m_ColorSaturationMax = 1;
+
+    // Particle
+    this.m_ParticleSpeed = 0;
+    this.m_ParticleRate = 0;
+    this.m_ParticleInitialRotationRange = 0;
+    this.m_RandomizeAlpha = false;
+
+    // QuadBatch
+    this.m_SprayRateMultiplier = 0;
+    this.m_RotationVariance = 0;
+    this.m_PositionVariance = 0;
+    this.m_SizeRatio = [1, 1];
+
+    // Geometry Brush
+    this.m_M11Compatibility = false;
+
+    // Tube
+    this.m_SolidMinLengthMeters_PS = 0.002;
+    this.m_TubeStoreRadiusInTexcoord0Z = false;
+
+    // Misc
+    this.m_RenderBackfaces = false;
+    this.m_BackIsInvisible = false;
+    this.m_BackfaceHueShift = 0;
+    this.m_BoundsPadding = 0;
   }
 
-  pressureSizeMin(previewMode) {
-    return previewMode ? this.previewPressureSizeMin : this.pressureSizeRange[0];
+  get Description() {
+    // LocalizedString stub: use durable name if no localized string
+    return this.m_LocalizedDescription || this.m_DurableName;
+  }
+
+  get Material() {
+    return this.m_Material;
+  }
+
+  PressureSizeMin(previewMode) {
+    return previewMode ? this.m_PreviewPressureSizeMin : this.m_PressureSizeRange[0];
   }
 
   toString() {
-    return `BrushDescriptor<${this.description} ${this.guid}>`;
+    return `BrushDescriptor<${this.m_DurableName} ${this.m_Guid}>`;
   }
 }
-
-export default BrushDescriptor;

--- a/js/BrushDescriptor.js
+++ b/js/BrushDescriptor.js
@@ -1,0 +1,52 @@
+export class BrushDescriptor {
+  constructor({
+    guid = '',
+    durableName = '',
+    description = '',
+    brushPrefab = null,
+    tags = ['default'],
+    nondeterministic = false,
+    supersedes = null,
+    looksIdentical = false,
+    hiddenInGui = false,
+    material = null,
+    textureAtlasV = 1,
+    tileRate = 1,
+    brushSizeRange = [0, 0],
+    pressureSizeRange = [0.1, 1],
+    sizeVariance = 0,
+    previewPressureSizeMin = 0.001,
+    pressureOpacityRange = [0, 1],
+    opacity = 1,
+  } = {}) {
+    this.guid = guid;
+    this.durableName = durableName;
+    this.description = description;
+    this.brushPrefab = brushPrefab;
+    this.tags = tags;
+    this.nondeterministic = nondeterministic;
+    this.supersedes = supersedes;
+    this.supersededBy = null;
+    this.looksIdentical = looksIdentical;
+    this.hiddenInGui = hiddenInGui;
+    this.material = material;
+    this.textureAtlasV = textureAtlasV;
+    this.tileRate = tileRate;
+    this.brushSizeRange = brushSizeRange;
+    this.pressureSizeRange = pressureSizeRange;
+    this.sizeVariance = sizeVariance;
+    this.previewPressureSizeMin = previewPressureSizeMin;
+    this.pressureOpacityRange = pressureOpacityRange;
+    this.opacity = opacity;
+  }
+
+  pressureSizeMin(previewMode) {
+    return previewMode ? this.previewPressureSizeMin : this.pressureSizeRange[0];
+  }
+
+  toString() {
+    return `BrushDescriptor<${this.description} ${this.guid}>`;
+  }
+}
+
+export default BrushDescriptor;

--- a/js/BrushManifest.js
+++ b/js/BrushManifest.js
@@ -1,0 +1,20 @@
+// Port of Tilt Brush's BrushManifest ScriptableObject to JavaScript.
+// Holds the list of available brushes and compatibility brushes.
+export default class BrushManifest {
+  constructor() {
+    // Array of BrushDescriptor
+    this.Brushes = [];
+    // Array of BrushDescriptor that are hidden but still loadable
+    this.CompatibilityBrushes = [];
+  }
+
+  // Create a manifest from a plain JSON object
+  static fromJSON(json) {
+    const manifest = new BrushManifest();
+    if (json) {
+      manifest.Brushes = json.Brushes ? Array.from(json.Brushes) : [];
+      manifest.CompatibilityBrushes = json.CompatibilityBrushes ? Array.from(json.CompatibilityBrushes) : [];
+    }
+    return manifest;
+  }
+}

--- a/js/ControlPoint.js
+++ b/js/ControlPoint.js
@@ -1,0 +1,12 @@
+import { Vector3, Quaternion } from 'three';
+
+export class ControlPoint {
+  constructor(pos = new Vector3(), orient = new Quaternion(), pressure = 0, timestampMs = 0) {
+    this.pos = pos;
+    this.orient = orient;
+    this.pressure = pressure;
+    this.timestampMs = timestampMs;
+  }
+}
+
+export default ControlPoint;

--- a/js/Coords.js
+++ b/js/Coords.js
@@ -1,0 +1,12 @@
+import { GlobalAccessor, LocalAccessor, RelativeAccessor } from './TransformExtensions.js';
+
+/**
+ * Coordinate system helpers mirroring Tilt Brush's Coords class.
+ * AsRoom and AsCanvas are placeholders until full scene infrastructure exists.
+ */
+export default class Coords {}
+
+Coords.AsRoom = undefined; // TODO: define room-space accessor
+Coords.AsGlobal = new GlobalAccessor();
+Coords.AsLocal = new LocalAccessor();
+Coords.AsCanvas = undefined; // Deprecated; provided by canvas instances

--- a/js/GeometryBrush.js
+++ b/js/GeometryBrush.js
@@ -1,10 +1,3 @@
-import {
-  CatmullRomCurve3,
-  Mesh,
-  MeshStandardMaterial,
-  TubeGeometry,
-  Vector3,
-} from 'three';
 import { BaseBrush } from './BaseBrush.js';
 
 // Simplified port of Tilt Brush's GeometryBrush base class.

--- a/js/GeometryBrush.js
+++ b/js/GeometryBrush.js
@@ -16,6 +16,17 @@ export class GeometryBrush extends BaseBrush {
     this.controlPoints.length = 0;
   }
 
+  resetBrushForPreview(unusedXf) {
+    super.resetBrushForPreview(unusedXf);
+    this.controlPoints.length = 0;
+    if (this.mesh) {
+      this.group.remove(this.mesh);
+      this.mesh.geometry.dispose();
+      this.mesh.material.dispose();
+      this.mesh = null;
+    }
+  }
+
   // Store control points for later geometry generation.
   addControlPoint(cp) {
     this.controlPoints.push(cp);

--- a/js/GeometryBrush.js
+++ b/js/GeometryBrush.js
@@ -1,0 +1,51 @@
+import {
+  CatmullRomCurve3,
+  Mesh,
+  MeshStandardMaterial,
+  TubeGeometry,
+  Vector3,
+} from 'three';
+import { BaseBrush } from './BaseBrush.js';
+
+// Simplified port of Tilt Brush's GeometryBrush base class.
+// Handles control-point collection and delegates mesh creation to subclasses.
+export class GeometryBrush extends BaseBrush {
+  constructor({ canBatch = true, upperBoundVertsPerKnot = 0, doubleSided = false } = {}) {
+    super(canBatch);
+    this.m_UpperBoundVertsPerKnot = upperBoundVertsPerKnot;
+    this.m_bDoubleSided = doubleSided;
+    this.controlPoints = [];
+    this.mesh = null;
+  }
+
+  initBrush(desc, localPointerXf) {
+    super.initBrush(desc, localPointerXf);
+    this.controlPoints.length = 0;
+  }
+
+  // Store control points for later geometry generation.
+  addControlPoint(cp) {
+    this.controlPoints.push(cp);
+  }
+
+  // Subclasses should override to build their specific mesh.
+  createMesh() {
+    // TODO: implement in subclasses
+    return null;
+  }
+
+  finalizeStroke() {
+    if (this.mesh) {
+      this.group.remove(this.mesh);
+      this.mesh.geometry.dispose();
+      this.mesh.material.dispose();
+    }
+    const mesh = this.createMesh();
+    if (mesh) {
+      this.mesh = mesh;
+      this.group.add(mesh);
+    }
+  }
+}
+
+export default GeometryBrush;

--- a/js/HSLColor.js
+++ b/js/HSLColor.js
@@ -1,0 +1,121 @@
+import { Color } from 'three';
+
+function colorCalc(c, t1, t2) {
+  if (c < 0) {
+    c += 6;
+  } else if (c >= 6) {
+    c -= 6;
+  }
+  if (c < 1) return t1 + (t2 - t1) * c;
+  if (c < 3) return t2;
+  if (c < 4) return t1 + (t2 - t1) * (4 - c);
+  return t1;
+}
+
+export class HSLColor {
+  static HUE_MAX = 6;
+
+  constructor(h = 0, s = 0, l = 0, a = 1) {
+    h = h % HSLColor.HUE_MAX;
+    if (h < 0) h += HSLColor.HUE_MAX;
+    this.h = h;
+    this.s = s;
+    this.l = l;
+    this.a = a;
+  }
+
+  get hueDegrees() {
+    return this.h * (360 / HSLColor.HUE_MAX);
+  }
+
+  set hueDegrees(value) {
+    value = ((value * HSLColor.HUE_MAX) / 360) % HSLColor.HUE_MAX;
+    if (value < 0) value += HSLColor.HUE_MAX;
+    this.h = value;
+  }
+
+  get hue01() {
+    return this.h * (1 / HSLColor.HUE_MAX);
+  }
+
+  set hue01(value) {
+    value = (value * HSLColor.HUE_MAX) % HSLColor.HUE_MAX;
+    if (value < 0) value += HSLColor.HUE_MAX;
+    this.h = value;
+  }
+
+  toColor() {
+    if (this.s === 0) {
+      const gray = new Color(this.l, this.l, this.l);
+      return { color: gray, a: this.a };
+    }
+    let t2;
+    if (this.l < 0.5) {
+      t2 = this.l * (1 + this.s);
+    } else {
+      t2 = this.l + this.s - this.l * this.s;
+    }
+    const t1 = 2 * this.l - t2;
+    const th = this.h * (6 / HSLColor.HUE_MAX);
+    const tr = th + 2;
+    const tg = th;
+    const tb = th - 2;
+    const color = new Color(
+      colorCalc(tr, t1, t2),
+      colorCalc(tg, t1, t2),
+      colorCalc(tb, t1, t2)
+    );
+    return { color, a: this.a };
+  }
+
+  static fromColor(color, a = 1) {
+    const r = color.r;
+    const g = color.g;
+    const b = color.b;
+    const min = Math.min(r, g, b);
+    const max = Math.max(r, g, b);
+    const delta = max - min;
+    let h = 0;
+    let s = 0;
+    const l = (max + min) * 0.5;
+    if (delta !== 0) {
+      if (l < 0.5) {
+        s = delta / (max + min);
+      } else {
+        s = delta / (2 - max - min);
+      }
+      if (r === max) {
+        h = (g - b) / delta;
+      } else if (g === max) {
+        h = 2 + (b - r) / delta;
+      } else {
+        h = 4 + (r - g) / delta;
+      }
+    }
+    h *= HSLColor.HUE_MAX / 6;
+    return new HSLColor(h, s, l, a);
+  }
+
+  static fromHSV(h, s, v, a = 1) {
+    h = h % HSLColor.HUE_MAX;
+    if (h < 0) h += HSLColor.HUE_MAX;
+    const l = v - 0.5 * s * v;
+    let s2;
+    if (l <= 0.5) {
+      s2 = s / (2 - s);
+    } else {
+      s2 = (s * v) / (2 * (1 - v) + s * v);
+    }
+    return new HSLColor(h, s2, l, a);
+  }
+
+  getBaseColor() {
+    return new HSLColor(this.h, this.s, 0.5, this.a);
+  }
+
+  toString() {
+    return `HSLA(${this.h.toFixed(3)}, ${this.s.toFixed(3)}, ${this.l.toFixed(3)}, ${this.a.toFixed(3)})`;
+  }
+}
+
+export default HSLColor;

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -3,6 +3,7 @@ import { TrTransform } from './TrTransform.js';
 import { ControlPoint } from './ControlPoint.js';
 import { TubeBrush } from './TubeBrush.js';
 import BrushCatalog from './BrushCatalog.js';
+import BrushDescriptor from './BrushDescriptor.js';
 
 export function createCircleStroke(scene) {
   const canvas = new Group();
@@ -30,8 +31,13 @@ export function createCircleStroke(scene) {
     controlPoints.push(cp);
   }
 
-  const catalog = BrushCatalog.createDefault();
-  const desc = catalog.getDescriptorByName('TubeBrush');
+  const tubeDesc = new BrushDescriptor();
+  tubeDesc.m_Guid = 'tube-brush';
+  tubeDesc.m_DurableName = 'TubeBrush';
+  tubeDesc.m_LocalizedDescription = 'Tube Brush';
+  const manifest = { Brushes: [tubeDesc], CompatibilityBrushes: [] };
+  BrushCatalog.Init(manifest);
+  const desc = BrushCatalog.GetBrush('tube-brush');
   const brush = new TubeBrush();
   brush.m_Color = new Color('blue');
   brush.BaseSize_PS = 0.05;

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -2,6 +2,7 @@ import { Group, Vector3, Quaternion, Color } from 'three';
 import { ControlPoint } from './ControlPoint.js';
 import BrushCatalog from './BrushCatalog.js';
 import BrushDescriptor from './BrushDescriptor.js';
+import BrushManifest from './BrushManifest.js';
 import Pointer from './Pointer.js';
 import { Stroke } from './Stroke.js';
 import TubeBrush from './TubeBrush.js';
@@ -32,7 +33,7 @@ export function createCircleStroke(scene) {
   tubeDesc.m_DurableName = 'TubeBrush';
   tubeDesc.m_LocalizedDescription = 'Tube Brush';
   tubeDesc.m_BrushPrefab = TubeBrush;
-  const manifest = { Brushes: [tubeDesc], CompatibilityBrushes: [] };
+  const manifest = BrushManifest.fromJSON({ Brushes: [tubeDesc], CompatibilityBrushes: [] });
   BrushCatalog.Init(manifest);
 
   const pointer = new Pointer(canvas);

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -1,14 +1,11 @@
 import { Group, Vector3, Quaternion, Color } from 'three';
 import { TrTransform } from './TrTransform.js';
 import { ControlPoint } from './ControlPoint.js';
-import { Stroke } from './Stroke.js';
-import { Pointer } from './Pointer.js';
+import { TubeBrush } from './TubeBrush.js';
 
 export function createCircleStroke(scene) {
   const canvas = new Group();
   scene.add(canvas);
-
-  const pointer = new Pointer(canvas);
 
   const path = [];
   const segments = 32;
@@ -32,17 +29,15 @@ export function createCircleStroke(scene) {
     controlPoints.push(cp);
   }
 
-  const stroke = new Stroke();
-  stroke.intendedCanvas = canvas;
-  stroke.brushGuid = 'default';
-  stroke.brushScale = 1;
-  stroke.brushSize = 0.05;
-  stroke.color = new Color('blue');
-  stroke.seed = 0;
-  stroke.controlPoints = controlPoints;
-  stroke.controlPointsToDrop = new Array(controlPoints.length).fill(false);
+  const brush = new TubeBrush();
+  brush.m_Color = new Color('blue');
+  brush.BaseSize_PS = 0.05;
+  brush.initBrush({ description: 'TubeBrush' }, TrTransform.identity);
+  for (const cp of controlPoints) {
+    brush.addControlPoint(cp);
+  }
+  brush.finalizeStroke();
+  canvas.add(brush.group);
 
-  stroke.recreate(pointer, TrTransform.identity, canvas);
-
-  return { canvas, stroke };
+  return { canvas, brush };
 }

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -7,7 +7,7 @@ import { Pointer } from './Pointer.js';
 import { Stroke } from './Stroke.js';
 import TubeBrush from './TubeBrush.js';
 
-export function createCircleStroke(scene) {
+export function createCircleStroke(scene, shape = TubeBrush.ShapeModifier.NONE) {
   const canvas = new Group();
   scene.add(canvas);
 
@@ -37,6 +37,7 @@ export function createCircleStroke(scene) {
   stroke.color = new Color('blue');
   stroke.brushGuid = 'tube-brush';
   stroke.brushSize = 0.05;
+  stroke.shapeModifier = shape;
 
   const tubeDesc = new BrushDescriptor();
   tubeDesc.m_Guid = 'tube-brush';

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -4,6 +4,7 @@ import BrushCatalog from './BrushCatalog.js';
 import BrushDescriptor from './BrushDescriptor.js';
 import Pointer from './Pointer.js';
 import { Stroke } from './Stroke.js';
+import TubeBrush from './TubeBrush.js';
 
 export function createCircleStroke(scene) {
   const canvas = new Group();
@@ -30,6 +31,7 @@ export function createCircleStroke(scene) {
   tubeDesc.m_Guid = 'tube-brush';
   tubeDesc.m_DurableName = 'TubeBrush';
   tubeDesc.m_LocalizedDescription = 'Tube Brush';
+  tubeDesc.m_BrushPrefab = TubeBrush;
   const manifest = { Brushes: [tubeDesc], CompatibilityBrushes: [] };
   BrushCatalog.Init(manifest);
 

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -2,6 +2,7 @@ import { Group, Vector3, Quaternion, Color } from 'three';
 import { TrTransform } from './TrTransform.js';
 import { ControlPoint } from './ControlPoint.js';
 import { TubeBrush } from './TubeBrush.js';
+import BrushCatalog from './BrushCatalog.js';
 
 export function createCircleStroke(scene) {
   const canvas = new Group();
@@ -29,10 +30,12 @@ export function createCircleStroke(scene) {
     controlPoints.push(cp);
   }
 
+  const catalog = BrushCatalog.createDefault();
+  const desc = catalog.getDescriptorByName('TubeBrush');
   const brush = new TubeBrush();
   brush.m_Color = new Color('blue');
   brush.BaseSize_PS = 0.05;
-  brush.initBrush({ description: 'TubeBrush' }, TrTransform.identity);
+  brush.initBrush(desc, TrTransform.identity);
   for (const cp of controlPoints) {
     brush.addControlPoint(cp);
   }

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -19,7 +19,8 @@ export function createCircleStroke(scene) {
     const position = new Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
     const radial = new Vector3(Math.cos(angle), Math.sin(angle), 0);
     const tangent = new Vector3(-Math.sin(angle), Math.cos(angle), 0);
-    const matrix = new Matrix4().makeBasis(radial, new Vector3(0, 0, 1), tangent);
+    const binormal = new Vector3().crossVectors(tangent, radial).normalize();
+    const matrix = new Matrix4().makeBasis(radial, binormal, tangent);
     const rotation = new Quaternion().setFromRotationMatrix(matrix);
     const cp = new ControlPoint(position, rotation, 1, i);
     controlPoints.push(cp);

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -42,5 +42,7 @@ export function createCircleStroke(scene) {
   brush.finalizeStroke();
   canvas.add(brush.group);
 
+  console.log(`Created TubeBrush stroke with ${controlPoints.length} control points`);
+
   return { canvas, brush };
 }

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -1,12 +1,10 @@
-import { Scene, Group, Vector3, Quaternion, Color } from 'three';
-import { pathToFileURL } from 'node:url';
+import { Group, Vector3, Quaternion, Color } from 'three';
 import { TrTransform } from './TrTransform.js';
 import { ControlPoint } from './ControlPoint.js';
-import { Stroke, StrokeType } from './Stroke.js';
+import { Stroke } from './Stroke.js';
 import { Pointer } from './Pointer.js';
 
-export function drawCircle() {
-  const scene = new Scene();
+export function createCircleStroke(scene) {
   const canvas = new Group();
   scene.add(canvas);
 
@@ -38,7 +36,7 @@ export function drawCircle() {
   stroke.intendedCanvas = canvas;
   stroke.brushGuid = 'default';
   stroke.brushScale = 1;
-  stroke.brushSize = 1;
+  stroke.brushSize = 0.05;
   stroke.color = new Color('blue');
   stroke.seed = 0;
   stroke.controlPoints = controlPoints;
@@ -46,10 +44,5 @@ export function drawCircle() {
 
   stroke.recreate(pointer, TrTransform.identity, canvas);
 
-  console.log(`Created stroke with ${controlPoints.length} control points.`);
-  console.log(`Canvas has ${canvas.children.length} object(s).`);
-}
-
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  drawCircle();
+  return { canvas, stroke };
 }

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -1,0 +1,55 @@
+import { Scene, Group, Vector3, Quaternion, Color } from 'three';
+import { pathToFileURL } from 'node:url';
+import { TrTransform } from './TrTransform.js';
+import { ControlPoint } from './ControlPoint.js';
+import { Stroke, StrokeType } from './Stroke.js';
+import { Pointer } from './Pointer.js';
+
+export function drawCircle() {
+  const scene = new Scene();
+  const canvas = new Group();
+  scene.add(canvas);
+
+  const pointer = new Pointer(canvas);
+
+  const path = [];
+  const segments = 32;
+  const radius = 1.5;
+  for (let i = 0; i < segments; i++) {
+    const angle = (i * 2 * Math.PI) / segments;
+    const position = new Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
+    const rotation = new Quaternion().setFromAxisAngle(new Vector3(0, 0, 1), angle);
+    path.push(TrTransform.TRS(position, rotation, 1));
+  }
+
+  const controlPoints = [];
+  let time = 0;
+  for (const tr of path) {
+    const cp = new ControlPoint(
+      tr.translation.clone(),
+      tr.rotation.clone(),
+      tr.scale,
+      time++
+    );
+    controlPoints.push(cp);
+  }
+
+  const stroke = new Stroke();
+  stroke.intendedCanvas = canvas;
+  stroke.brushGuid = 'default';
+  stroke.brushScale = 1;
+  stroke.brushSize = 1;
+  stroke.color = new Color('blue');
+  stroke.seed = 0;
+  stroke.controlPoints = controlPoints;
+  stroke.controlPointsToDrop = new Array(controlPoints.length).fill(false);
+
+  stroke.recreate(pointer, TrTransform.identity, canvas);
+
+  console.log(`Created stroke with ${controlPoints.length} control points.`);
+  console.log(`Canvas has ${canvas.children.length} object(s).`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  drawCircle();
+}

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -3,7 +3,7 @@ import { ControlPoint } from './ControlPoint.js';
 import BrushCatalog from './BrushCatalog.js';
 import BrushDescriptor from './BrushDescriptor.js';
 import BrushManifest from './BrushManifest.js';
-import Pointer from './Pointer.js';
+import { Pointer } from './Pointer.js';
 import { Stroke } from './Stroke.js';
 import TubeBrush from './TubeBrush.js';
 

--- a/js/Pointer.js
+++ b/js/Pointer.js
@@ -24,6 +24,9 @@ export class Pointer {
       this.currentBrush.m_Color.copy(stroke.color);
     }
     this.currentBrush.BaseSize_PS = stroke.brushSize || 0.01;
+    if (stroke.shapeModifier) {
+      this.currentBrush.shapeModifier = stroke.shapeModifier;
+    }
     this.currentBrush.initBrush(desc, TrTransform.identity);
     this.currentStroke = stroke;
     this.currentStroke.controlPoints = this.currentStroke.controlPoints || [];

--- a/js/Pointer.js
+++ b/js/Pointer.js
@@ -1,5 +1,4 @@
 import { StrokeType } from './Stroke.js';
-import { TubeBrush } from './TubeBrush.js';
 import { TrTransform } from './TrTransform.js';
 import BrushCatalog from './BrushCatalog.js';
 
@@ -11,12 +10,16 @@ export class Pointer {
   }
 
   /**
-   * Begin a stroke using the provided Stroke data. The stroke should have
-   * brushGuid, color, brushSize, and optional brushScale fields populated.
-   */
+  * Begin a stroke using the provided Stroke data. The stroke should have
+  * brushGuid, color, brushSize, and optional brushScale fields populated.
+  */
   beginStroke(stroke) {
     const desc = BrushCatalog.GetBrush(stroke.brushGuid);
-    this.currentBrush = new TubeBrush();
+    if (!desc || !desc.m_BrushPrefab) {
+      console.error(`No brush prefab for guid ${stroke.brushGuid}`);
+      return;
+    }
+    this.currentBrush = new desc.m_BrushPrefab();
     if (stroke.color) {
       this.currentBrush.m_Color.copy(stroke.color);
     }

--- a/js/Pointer.js
+++ b/js/Pointer.js
@@ -1,0 +1,42 @@
+import { BufferGeometry, LineBasicMaterial, LineLoop } from 'three';
+import { StrokeType } from './Stroke.js';
+
+export class Pointer {
+  constructor(canvas) {
+    this.canvas = canvas;
+  }
+
+  // TODO: initialize drawing with the given brush
+  beginStroke(brush) {
+    // Implementation will integrate brush-specific behavior
+  }
+
+  // TODO: add a new control point to the current stroke
+  updateStroke(controlPoint) {
+    // Implementation will build stroke geometry incrementally
+  }
+
+  // TODO: finalize the stroke and commit geometry
+  endStroke() {
+    // Implementation will finalize stroke creation
+  }
+
+  recreateLineFromMemory(stroke) {
+    const points = stroke.controlPoints.map(cp => cp.pos);
+    const geometry = new BufferGeometry().setFromPoints(points);
+    const material = new LineBasicMaterial({ color: stroke.color });
+    const line = new LineLoop(geometry, material);
+    this.canvas.add(line);
+    stroke.object = {
+      canvas: this.canvas,
+      hideBrush: hide => {
+        line.visible = !hide;
+      },
+      setParent: parent => {
+        parent.add(line);
+        this.canvas = parent;
+      },
+    };
+    stroke.type = StrokeType.BrushStroke;
+  }
+}

--- a/js/QuaternionExtensions.js
+++ b/js/QuaternionExtensions.js
@@ -1,0 +1,85 @@
+import { Quaternion, Vector3 } from 'three';
+
+/**
+ * Utilities mirroring Tilt Brush's QuaternionExtensions.
+ */
+export default class QuaternionExtensions {
+  /**
+   * Creates a quaternion rotating by `angle` radians around `axis`.
+   */
+  static angleAxisRad(angle, axis) {
+    const q = new Quaternion();
+    q.setFromAxisAngle(axis, angle);
+    return q;
+  }
+
+  /**
+   * Quaternion logarithm; returns a quaternion whose xyz represent half-angle.
+   * The input must be unit-length.
+   */
+  static log(q) {
+    const vecLenSq = q.x * q.x + q.y * q.y + q.z * q.z;
+    const lenSq = vecLenSq + q.w * q.w;
+    if (Math.abs(lenSq - 1) > 3e-3) {
+      throw new Error('Quaternion must be unit');
+    }
+
+    const sinTheta = Math.sqrt(vecLenSq);
+    const theta = Math.atan2(sinTheta, q.w);
+
+    if (sinTheta < 1e-5) {
+      if (q.w > 0) {
+        return new Quaternion(q.x, q.y, q.z, 0);
+      }
+      const axis = new Vector3(q.x, q.y, q.z).normalize();
+      if (axis.lengthSq() === 0) axis.set(0, 1, 0);
+      axis.multiplyScalar(theta);
+      return new Quaternion(axis.x, axis.y, axis.z, 0);
+    } else {
+      const k = theta / sinTheta;
+      return new Quaternion(k * q.x, k * q.y, k * q.z, 0);
+    }
+  }
+
+  /**
+   * Quaternion exponentiation; input must have w === 0.
+   */
+  static exp(q) {
+    if (q.w !== 0) {
+      throw new Error('Quaternion must be pure (w=0)');
+    }
+    const v = new Vector3(q.x, q.y, q.z);
+    const vLen = v.length();
+    let sinVOverV;
+    if (vLen < 1e-4) {
+      sinVOverV = vLen;
+    } else {
+      sinVOverV = Math.sin(vLen) / vLen;
+    }
+
+    v.multiplyScalar(sinVOverV);
+    return new Quaternion(v.x, v.y, v.z, Math.cos(vLen));
+  }
+
+  /**
+   * Returns the negated quaternion.
+   */
+  static negated(q) {
+    return new Quaternion(-q.x, -q.y, -q.z, -q.w);
+  }
+
+  /**
+   * Returns the imaginary component of the quaternion.
+   */
+  static im(q) {
+    return new Vector3(q.x, q.y, q.z);
+  }
+
+  /**
+   * Returns the inverse without assuming unit-length.
+   */
+  static trueInverse(q) {
+    const f = 1 / q.lengthSq();
+    return new Quaternion(-q.x * f, -q.y * f, -q.z * f, q.w * f);
+  }
+}

--- a/js/Stroke.js
+++ b/js/Stroke.js
@@ -1,0 +1,148 @@
+import { Vector3, Quaternion } from 'three';
+import { StrokeData } from './StrokeData.js';
+
+export const StrokeType = Object.freeze({
+  NotCreated: 0,
+  BrushStroke: 1,
+  BatchedBrushStroke: 2,
+});
+
+/**
+ * Port of Tilt Brush's Stroke class. Handles stroke metadata and basic
+ * transformation logic without any Unity-specific rendering code.
+ */
+export class Stroke extends StrokeData {
+  constructor(existing = null) {
+    super(existing);
+    this.type = StrokeType.NotCreated;
+    this.intendedCanvas = null;
+    this.object = null;
+    this.copyForSaveThread = null;
+    this.controlPointsToDrop = existing ? [...(existing.controlPointsToDrop || [])] : [];
+  }
+
+  get canvas() {
+    if (this.type === StrokeType.NotCreated) {
+      return this.intendedCanvas;
+    }
+    if (this.type === StrokeType.BrushStroke) {
+      return this.object ? this.object.canvas : null;
+    }
+    throw new Error('Invalid stroke type');
+  }
+
+  invalidateCopy() {
+    this.copyForSaveThread = null;
+  }
+
+  uncreate() {
+    this.intendedCanvas = this.canvas;
+    this.object = null;
+    this.type = StrokeType.NotCreated;
+  }
+
+  setParent(canvas) {
+    const prevCanvas = this.canvas;
+    if (prevCanvas === canvas) {
+      return;
+    }
+
+    if (this.type === StrokeType.BrushStroke && this.object && typeof this.object.setParent === 'function') {
+      this.object.setParent(canvas);
+    } else {
+      this.intendedCanvas = canvas;
+    }
+  }
+
+  /**
+   * Applies a left transform to all control points. The transform should be an
+   * object with { position: Vector3, rotation: Quaternion, scale: number }.
+   * The brushScale is updated by the transform and the cached copy is invalidated.
+   */
+  leftTransformControlPoints(transform, absoluteScale = false) {
+    let position, rotation, scale;
+    if (transform && transform.translation) {
+      position = transform.translation;
+      rotation = transform.rotation;
+      scale = transform.scale;
+    } else {
+      ({ position = new Vector3(), rotation = new Quaternion(), scale = 1 } = transform || {});
+    }
+    for (const cp of this.controlPoints) {
+      cp.pos.multiplyScalar(scale);
+      cp.pos.applyQuaternion(rotation);
+      cp.pos.add(position);
+      cp.orient.premultiply(rotation);
+    }
+    this.brushScale *= absoluteScale ? Math.abs(scale) : scale;
+    this.invalidateCopy();
+  }
+
+  // TODO: port matrix-based variant
+  leftTransformControlPointsMatrix(matrix) {
+    // TODO: implement using Matrix4 operations
+    throw new Error('leftTransformControlPointsMatrix not implemented');
+  }
+
+  /**
+   * Set the parent canvas while preserving world-space position.
+   * If leftTransform is provided, it will be applied to the control points.
+   * When geometry exists, the stroke is recreated through the provided pointer.
+   */
+  setParentKeepWorldPosition(canvas, pointer, leftTransform = null, absoluteScale = false) {
+    const prevCanvas = this.canvas;
+    if (prevCanvas === canvas) {
+      return;
+    }
+
+    const transform = leftTransform;
+    if (this.type === StrokeType.NotCreated || !transform) {
+      this.setParent(canvas);
+      if (transform) {
+        this.leftTransformControlPoints(transform, absoluteScale);
+      }
+    } else if (this.type === StrokeType.BrushStroke) {
+      this.uncreate();
+      this.intendedCanvas = canvas;
+      this.leftTransformControlPoints(transform, absoluteScale);
+      if (pointer && typeof pointer.recreateLineFromMemory === 'function') {
+        pointer.recreateLineFromMemory(this);
+      }
+    } else {
+      this.setParent(canvas);
+    }
+  }
+
+  /**
+   * Hide or show the stroke's geometry if possible.
+   */
+  hide(hide) {
+    if (this.type === StrokeType.BrushStroke && this.object && typeof this.object.hideBrush === 'function') {
+      this.object.hideBrush(hide);
+    } else if (this.type === StrokeType.NotCreated) {
+      console.error('Unexpected: NotCreated stroke');
+    }
+  }
+
+  // Placeholder for full recreate logic; only handles basic transform/parenting.
+  recreate(pointer, leftTransform = null, canvas = null, absoluteScale = false) {
+    if (leftTransform || this.type === StrokeType.NotCreated) {
+      this.uncreate();
+      if (canvas) {
+        this.setParent(canvas);
+      }
+      if (leftTransform) {
+        this.leftTransformControlPoints(leftTransform, absoluteScale);
+      }
+      if (pointer && typeof pointer.recreateLineFromMemory === 'function') {
+        pointer.recreateLineFromMemory(this);
+      }
+    } else if (canvas) {
+      this.setParent(canvas);
+    } else {
+      throw new Error('Nothing to do');
+    }
+  }
+}
+
+export default Stroke;

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -9,6 +9,7 @@ export class StrokeData {
       this.brushSize = existing.brushSize;
       this.brushScale = existing.brushScale;
       this.seed = existing.seed;
+      this.shapeModifier = existing.shapeModifier;
       this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
         cp.pos?.clone ? cp.pos.clone() : cp.pos,
         cp.orient?.clone ? cp.orient.clone() : cp.orient,
@@ -22,6 +23,7 @@ export class StrokeData {
       this.brushScale = 1;
       this.seed = 0;
       this.controlPoints = [];
+      this.shapeModifier = null;
     }
 
     const uuidFn = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -1,0 +1,31 @@
+import { Color } from 'three';
+import { randomUUID } from 'node:crypto';
+import { ControlPoint } from './ControlPoint.js';
+
+export class StrokeData {
+  constructor(existing = null) {
+    if (existing) {
+      this.color = existing.color?.clone ? existing.color.clone() : existing.color;
+      this.brushGuid = existing.brushGuid;
+      this.brushSize = existing.brushSize;
+      this.brushScale = existing.brushScale;
+      this.seed = existing.seed;
+      this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
+        cp.pos?.clone ? cp.pos.clone() : cp.pos,
+        cp.orient?.clone ? cp.orient.clone() : cp.orient,
+        cp.pressure,
+        cp.timestampMs
+      ));
+    } else {
+      this.color = new Color();
+      this.brushGuid = null;
+      this.brushSize = 0;
+      this.brushScale = 1;
+      this.seed = 0;
+      this.controlPoints = [];
+    }
+    this.guid = randomUUID();
+  }
+}
+
+export default StrokeData;

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -1,5 +1,4 @@
 import { Color } from 'three';
-import { randomUUID } from 'node:crypto';
 import { ControlPoint } from './ControlPoint.js';
 
 export class StrokeData {
@@ -24,7 +23,12 @@ export class StrokeData {
       this.seed = 0;
       this.controlPoints = [];
     }
-    this.guid = randomUUID();
+
+    const uuidFn = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'
+      ? () => globalThis.crypto.randomUUID()
+      : () => Math.random().toString(36).slice(2);
+
+    this.guid = uuidFn();
   }
 }
 

--- a/js/TrTransform.js
+++ b/js/TrTransform.js
@@ -50,13 +50,25 @@ export class TrTransform {
   }
 
   static fromTransform(xf) {
-    // TODO: Implement using three.js Object3D
-    throw new Error('fromTransform not implemented');
+    if (!xf) {
+      throw new Error('fromTransform requires an Object3D');
+    }
+    xf.updateMatrixWorld();
+    const t = new Vector3();
+    const r = new Quaternion();
+    const s = new Vector3();
+    xf.matrixWorld.decompose(t, r, s);
+    return new TrTransform(t, r, s.x);
   }
 
   static fromLocalTransform(xf) {
-    // TODO: Implement using three.js Object3D
-    throw new Error('fromLocalTransform not implemented');
+    if (!xf) {
+      throw new Error('fromLocalTransform requires an Object3D');
+    }
+    const t = xf.position.clone();
+    const r = xf.quaternion.clone();
+    const s = xf.scale.x;
+    return new TrTransform(t, r, s);
   }
 
   static invMul(a, b) {
@@ -185,13 +197,29 @@ export class TrTransform {
   }
 
   toTransform(xf) {
-    // TODO: Implement using three.js Object3D
-    throw new Error('toTransform not implemented');
+    if (!xf) {
+      throw new Error('toTransform requires an Object3D');
+    }
+    const m = this.toMatrix4();
+    if (xf.parent) {
+      xf.parent.updateMatrixWorld();
+      const parentInv = new Matrix4().copy(xf.parent.matrixWorld).invert();
+      m.premultiply(parentInv);
+    }
+    m.decompose(xf.position, xf.quaternion, xf.scale);
+    xf.updateMatrix();
+    xf.updateMatrixWorld(true);
   }
 
   toLocalTransform(xf) {
-    // TODO: Implement using three.js Object3D
-    throw new Error('toLocalTransform not implemented');
+    if (!xf) {
+      throw new Error('toLocalTransform requires an Object3D');
+    }
+    xf.position.copy(this.translation);
+    xf.quaternion.copy(this.rotation);
+    xf.scale.setScalar(this.scale);
+    xf.updateMatrix();
+    xf.updateMatrixWorld(true);
   }
 
   transformBy(rhs) {

--- a/js/TrTransform.js
+++ b/js/TrTransform.js
@@ -1,0 +1,208 @@
+import { Vector3, Quaternion, Matrix4 } from 'three';
+import QuaternionExtensions from './QuaternionExtensions.js';
+
+/**
+ * Port of Tilt Brush's TrTransform struct.
+ * Represents translation, rotation, and uniform scale.
+ */
+export class TrTransform {
+  constructor(translation = new Vector3(), rotation = new Quaternion(), scale = 1) {
+    this.translation = translation;
+    this.rotation = rotation;
+    this.scale = scale;
+  }
+
+  static identity = TrTransform.TR(new Vector3(), new Quaternion());
+
+  // Methods analogous to Matrix4x4.TRS
+  static T(t) {
+    return new TrTransform(t, new Quaternion(), 1);
+  }
+
+  static RQuaternion(r) {
+    return new TrTransform(new Vector3(), r, 1);
+  }
+
+  static R(angle, axis) {
+    const q = new Quaternion().setFromAxisAngle(axis, angle);
+    return new TrTransform(new Vector3(), q, 1);
+  }
+
+  static S(s) {
+    return new TrTransform(new Vector3(), new Quaternion(), s);
+  }
+
+  static TR(t, r) {
+    return new TrTransform(t, r, 1);
+  }
+
+  static TRS(t, r, s) {
+    return new TrTransform(t, r, s);
+  }
+
+  static fromMatrix4(m) {
+    // TODO: decompose matrix; assumes uniform scale
+    const t = new Vector3();
+    const r = new Quaternion();
+    const s = new Vector3();
+    m.decompose(t, r, s);
+    return new TrTransform(t, r, s.x);
+  }
+
+  static fromTransform(xf) {
+    // TODO: Implement using three.js Object3D
+    throw new Error('fromTransform not implemented');
+  }
+
+  static fromLocalTransform(xf) {
+    // TODO: Implement using three.js Object3D
+    throw new Error('fromLocalTransform not implemented');
+  }
+
+  static invMul(a, b) {
+    const aInvRot = QuaternionExtensions.trueInverse(a.rotation);
+    const translation = b.translation
+      .clone()
+      .sub(a.translation)
+      .divideScalar(a.scale)
+      .applyQuaternion(aInvRot);
+    const rotation = aInvRot.clone().multiply(b.rotation);
+    const scale = b.scale / a.scale;
+    return TrTransform.TRS(translation, rotation, scale);
+  }
+
+  static lerp(a, b, t) {
+    const translation = a.translation.clone().lerp(b.translation, t);
+    const rotation = a.rotation.clone().slerp(b.rotation, t);
+    const scale = Math.exp(Math.log(a.scale) * (1 - t) + Math.log(b.scale) * t);
+    return new TrTransform(translation, rotation, scale);
+  }
+
+  multiplyPoint(p) {
+    return p
+      .clone()
+      .multiplyScalar(this.scale)
+      .applyQuaternion(this.rotation)
+      .add(this.translation);
+  }
+
+  multiplyVector(v) {
+    return v
+      .clone()
+      .multiplyScalar(this.scale)
+      .applyQuaternion(this.rotation);
+  }
+
+  multiplyBivector(v) {
+    return v
+      .clone()
+      .multiplyScalar(this.scale * this.scale)
+      .applyQuaternion(this.rotation);
+  }
+
+  multiplyNormal(v) {
+    return v.clone().applyQuaternion(this.rotation);
+  }
+
+  // TODO: implement plane transformation
+  multiplyPlane(plane) {
+    throw new Error('multiplyPlane not implemented');
+  }
+
+  mul(b) {
+    return TrTransform.TRS(
+      this.rotation.clone().multiply(b.translation.clone().multiplyScalar(this.scale)).add(this.translation),
+      this.rotation.clone().multiply(b.rotation),
+      this.scale * b.scale
+    );
+  }
+
+  static approximately(lhs, rhs) {
+    const sameTranslation = lhs.translation.equals(rhs.translation);
+    const sameRotation = lhs.rotation.equals(rhs.rotation);
+    const sameScale = Math.abs(lhs.scale - rhs.scale) <= Number.EPSILON;
+    return sameTranslation && sameRotation && sameScale;
+  }
+
+  get inverse() {
+    const rinv = QuaternionExtensions.trueInverse(this.rotation);
+    const invScale = 1 / this.scale;
+    const translation = this.translation
+      .clone()
+      .multiplyScalar(-invScale)
+      .applyQuaternion(rinv);
+    return TrTransform.TRS(translation, rinv, invScale);
+  }
+
+  forward() {
+    return new Vector3(0, 0, 1).applyQuaternion(this.rotation);
+  }
+
+  up() {
+    return new Vector3(0, 1, 0).applyQuaternion(this.rotation);
+  }
+
+  right() {
+    return new Vector3(1, 0, 0).applyQuaternion(this.rotation);
+  }
+
+  isFinite() {
+    return [
+      this.translation.x,
+      this.translation.y,
+      this.translation.z,
+      this.rotation.x,
+      this.rotation.y,
+      this.rotation.z,
+      this.rotation.w,
+      this.scale,
+    ].every(Number.isFinite);
+  }
+
+  toString() {
+    return `T: ${this.translation.x.toExponential()} ${this.translation.y.toExponential()} ${this.translation.z.toExponential()}\n` +
+      `R: ${this.rotation.x.toExponential()} ${this.rotation.y.toExponential()} ${this.rotation.z.toExponential()} ${this.rotation.w.toExponential()}\n` +
+      `S: ${this.scale.toExponential()}`;
+  }
+
+  equals(o) {
+    return (
+      o instanceof TrTransform &&
+      this.translation.equals(o.translation) &&
+      this.rotation.equals(o.rotation) &&
+      this.scale === o.scale
+    );
+  }
+
+  toMatrix4() {
+    const m = new Matrix4();
+    m.compose(
+      this.translation,
+      this.rotation,
+      new Vector3(this.scale, this.scale, this.scale)
+    );
+    return m;
+  }
+
+  toTransform(xf) {
+    // TODO: Implement using three.js Object3D
+    throw new Error('toTransform not implemented');
+  }
+
+  toLocalTransform(xf) {
+    // TODO: Implement using three.js Object3D
+    throw new Error('toLocalTransform not implemented');
+  }
+
+  transformBy(rhs) {
+    const similar = rhs.rotation.clone().multiply(this.rotation).multiply(QuaternionExtensions.trueInverse(rhs.rotation));
+    const retTrans = similar
+      .clone()
+      .multiply(rhs.translation.clone().multiplyScalar(-this.scale))
+      .add(rhs.rotation.clone().multiply(this.translation.clone().multiplyScalar(rhs.scale)))
+      .add(rhs.translation);
+    return new TrTransform(retTrans, similar, this.scale);
+  }
+}
+
+export default TrTransform;

--- a/js/TrTransform.js
+++ b/js/TrTransform.js
@@ -1,4 +1,4 @@
-import { Vector3, Quaternion, Matrix4 } from 'three';
+import { Vector3, Quaternion, Matrix4, Plane } from 'three';
 import QuaternionExtensions from './QuaternionExtensions.js';
 
 /**
@@ -116,9 +116,23 @@ export class TrTransform {
     return v.clone().applyQuaternion(this.rotation);
   }
 
-  // TODO: implement plane transformation
   multiplyPlane(plane) {
-    throw new Error('multiplyPlane not implemented');
+    if (!(plane instanceof Plane)) {
+      throw new Error('multiplyPlane requires a three.js Plane');
+    }
+    // Transform plane assuming uniform scale
+    const normal = plane.normal
+      .clone()
+      .applyQuaternion(this.rotation)
+      .multiplyScalar(1 / this.scale);
+    let constant = plane.constant - normal.dot(this.translation);
+    // Ensure the plane normal remains normalized
+    const len = normal.length();
+    if (len > 0) {
+      normal.multiplyScalar(1 / len);
+      constant *= 1 / len;
+    }
+    return new Plane(normal, constant);
   }
 
   mul(b) {

--- a/js/TransformExtensions.js
+++ b/js/TransformExtensions.js
@@ -1,0 +1,67 @@
+import { Vector3 } from 'three';
+import TrTransform from './TrTransform.js';
+
+/**
+ * Helpers for working with three.js Object3D transforms
+ * using Tilt Brush's TrTransform abstraction.
+ */
+export function getUniformScale(xf) {
+  let uniformScale = xf.scale.x;
+  for (let cur = xf.parent; cur; cur = cur.parent) {
+    uniformScale *= cur.scale.x;
+  }
+  return uniformScale;
+}
+
+export function setUniformScale(xf, scale) {
+  if (xf.parent) {
+    scale /= getUniformScale(xf.parent);
+  }
+  xf.scale.setScalar(scale);
+}
+
+export class LocalAccessor {
+  get(xf) {
+    return TrTransform.fromLocalTransform(xf);
+  }
+
+  set(xf, value) {
+    value.toLocalTransform(xf);
+  }
+}
+
+export class GlobalAccessor {
+  get(xf) {
+    return TrTransform.fromTransform(xf);
+  }
+
+  set(xf, value) {
+    value.toTransform(xf);
+  }
+}
+
+export class RelativeAccessor {
+  constructor(parent) {
+    this.parent = parent;
+    this.asGlobal = new GlobalAccessor();
+    this.asLocal = new LocalAccessor();
+  }
+
+  get(xf) {
+    // TODO: compute transform relative to parent
+    throw new Error('RelativeAccessor.get not implemented');
+  }
+
+  set(xf, value) {
+    // TODO: set transform relative to parent
+    throw new Error('RelativeAccessor.set not implemented');
+  }
+}
+
+export default {
+  getUniformScale,
+  setUniformScale,
+  LocalAccessor,
+  GlobalAccessor,
+  RelativeAccessor,
+};

--- a/js/TransformExtensions.js
+++ b/js/TransformExtensions.js
@@ -48,13 +48,19 @@ export class RelativeAccessor {
   }
 
   get(xf) {
-    // TODO: compute transform relative to parent
-    throw new Error('RelativeAccessor.get not implemented');
+    const parentTf = this.parent
+      ? TrTransform.fromTransform(this.parent)
+      : TrTransform.identity;
+    const childTf = TrTransform.fromTransform(xf);
+    return TrTransform.invMul(parentTf, childTf);
   }
 
   set(xf, value) {
-    // TODO: set transform relative to parent
-    throw new Error('RelativeAccessor.set not implemented');
+    const parentTf = this.parent
+      ? TrTransform.fromTransform(this.parent)
+      : TrTransform.identity;
+    const world = parentTf.mul(value);
+    world.toTransform(xf);
   }
 }
 

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -16,6 +16,51 @@ export class TubeBrush extends GeometryBrush {
     this.pointsInClosedCircle = 8;
   }
 
+  initBrush(desc, localPointerXf) {
+    super.initBrush(desc, localPointerXf);
+    // TODO: mirror TubeBrush-specific initialization from C# version
+  }
+
+  resetBrushForPreview(unusedXf) {
+    super.resetBrushForPreview(unusedXf);
+    // TODO: clear any TubeBrush preview-specific state
+  }
+
+  addControlPoint(cp) {
+    super.addControlPoint(cp);
+    this.controlPointsChanged(this.controlPoints.length - 1);
+  }
+
+  getSpawnInterval(pressure01) {
+    // TODO: compute spawn interval based on pressure and descriptor
+    return this.Descriptor?.m_SolidMinLengthMeters_PS || 0.002;
+  }
+
+  controlPointsChanged(startIndex) {
+    // TODO: implement geometry update for modified control points
+  }
+
+  onChangedFrameKnots(startIndex) {
+    // TODO: frame knots and detect strip breaks
+    return false;
+  }
+
+  onChangedMakeGeometry(startIndex) {
+    // TODO: generate mesh data for affected knots
+  }
+
+  resizeGeometry() {
+    // TODO: resize internal geometry buffers
+  }
+
+  onChangedStretchUVs(startIndex) {
+    // TODO: update UVs when stretch style is active
+  }
+
+  onChangedModifySilhouette(startIndex) {
+    // TODO: apply shape modifiers to the silhouette
+  }
+
   // Generate a tube mesh along control points without relying on Three.js helpers.
   createMesh() {
     const cpCount = this.controlPoints.length;

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -37,7 +37,14 @@ export class TubeBrush extends GeometryBrush {
   }
 
   controlPointsChanged(startIndex) {
-    // TODO: implement geometry update for modified control points
+    // For now, rebuild the entire mesh whenever control points change.
+    // This mirrors the C# behavior that regenerates geometry incrementally,
+    // but keeps the implementation simple until partial updates are ported.
+    if (this.controlPoints.length < 2) {
+      return;
+    }
+    // Recreate the mesh to reflect new control points.
+    this.finalizeStroke();
   }
 
   onChangedFrameKnots(startIndex) {

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -1,7 +1,7 @@
 import {
   CatmullRomCurve3,
   Mesh,
-  MeshStandardMaterial,
+  MeshBasicMaterial,
   TubeGeometry,
 } from 'three';
 import { GeometryBrush } from './GeometryBrush.js';
@@ -27,7 +27,8 @@ export class TubeBrush extends GeometryBrush {
     const radialSegments = this.pointsInClosedCircle;
     const closed = false;
     const geometry = new TubeGeometry(curve, tubularSegments, radius, radialSegments, closed);
-    const material = new MeshStandardMaterial({ color: this.CurrentColor });
+    // Use a basic material so the stroke is visible without scene lighting.
+    const material = new MeshBasicMaterial({ color: this.CurrentColor });
     return new Mesh(geometry, material);
   }
 }

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -1,0 +1,35 @@
+import {
+  CatmullRomCurve3,
+  Mesh,
+  MeshStandardMaterial,
+  TubeGeometry,
+} from 'three';
+import { GeometryBrush } from './GeometryBrush.js';
+import { ControlPoint } from './ControlPoint.js';
+
+// Port of Tilt Brush's TubeBrush. This simplified version builds a tube mesh
+// along the collected control points using Three.js's TubeGeometry.
+export class TubeBrush extends GeometryBrush {
+  constructor() {
+    super({ canBatch: true, upperBoundVertsPerKnot: 24, doubleSided: false });
+    this.pointsInClosedCircle = 8;
+  }
+
+  // Generate a tube mesh following the stored control points.
+  createMesh() {
+    if (this.controlPoints.length < 2) {
+      return null;
+    }
+    const curvePoints = this.controlPoints.map(cp => cp.pos.clone());
+    const curve = new CatmullRomCurve3(curvePoints, false);
+    const tubularSegments = Math.max(32, curvePoints.length * 8);
+    const radius = this.BaseSize_LS || 0.01;
+    const radialSegments = this.pointsInClosedCircle;
+    const closed = false;
+    const geometry = new TubeGeometry(curve, tubularSegments, radius, radialSegments, closed);
+    const material = new MeshStandardMaterial({ color: this.CurrentColor });
+    return new Mesh(geometry, material);
+  }
+}
+
+export default TubeBrush;

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -96,10 +96,13 @@ export class TubeBrush extends GeometryBrush {
     for (let i = 0; i < cpCount - 1; i++) {
       for (let j = 0; j < radialSegments; j++) {
         const a = i * radialSegments + j;
-        const b = a + radialSegments;
+        const b = (i + 1) * radialSegments + j;
         const c = i * radialSegments + (j + 1) % radialSegments;
-        const d = b + (j + 1) % radialSegments;
-        indices.push(a, b, c, c, b, d);
+        const d = (i + 1) * radialSegments + (j + 1) % radialSegments;
+
+        // Form two triangles for the quad between ring i and i+1 at segment j.
+        indices.push(a, b, d);
+        indices.push(a, d, c);
       }
     }
 

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -14,6 +14,7 @@ export class TubeBrush extends GeometryBrush {
   constructor() {
     super({ canBatch: true, upperBoundVertsPerKnot: 24, doubleSided: false });
     this.pointsInClosedCircle = 8;
+    this.shapeModifier = TubeBrush.ShapeModifier.NONE;
   }
 
   initBrush(desc, localPointerXf) {
@@ -90,8 +91,16 @@ export class TubeBrush extends GeometryBrush {
       const cp = this.controlPoints[i];
       for (let j = 0; j < radialSegments; j++) {
         const angle = (j / radialSegments) * Math.PI * 2;
-        tmpPos.set(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
+        // Base circle coordinates.
+        tmpPos.set(Math.cos(angle), Math.sin(angle), 0);
+        // Apply shape modification to cross-section coordinates.
+        if (this.shapeModifier === TubeBrush.ShapeModifier.SQUARE) {
+          const scale = 1 / Math.max(Math.abs(tmpPos.x), Math.abs(tmpPos.y));
+          tmpPos.x *= scale;
+          tmpPos.y *= scale;
+        }
         tmpNormal.copy(tmpPos).normalize();
+        tmpPos.multiplyScalar(radius);
         tmpPos.applyQuaternion(cp.orient).add(cp.pos);
         tmpNormal.applyQuaternion(cp.orient);
         positions.push(tmpPos.x, tmpPos.y, tmpPos.z);
@@ -124,5 +133,10 @@ export class TubeBrush extends GeometryBrush {
     return new Mesh(geometry, material);
   }
 }
+
+TubeBrush.ShapeModifier = {
+  NONE: 'none',
+  SQUARE: 'square',
+};
 
 export default TubeBrush;

--- a/js/VerifyTubeBrush.js
+++ b/js/VerifyTubeBrush.js
@@ -1,0 +1,71 @@
+import { Vector3, Quaternion, Matrix4, Color } from 'three';
+import { ControlPoint } from './ControlPoint.js';
+import TubeBrush from './TubeBrush.js';
+import { TrTransform } from './TrTransform.js';
+
+// Build a circular stroke similar to the minimal example
+function buildCircleControlPoints(segments = 16, radius = 1.5) {
+  const cps = [];
+  for (let i = 0; i < segments; i++) {
+    const angle = (i * 2 * Math.PI) / segments;
+    const position = new Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
+    const radial = new Vector3(Math.cos(angle), Math.sin(angle), 0);
+    const tangent = new Vector3(-Math.sin(angle), Math.cos(angle), 0);
+    const matrix = new Matrix4().makeBasis(radial, new Vector3(0, 0, 1), tangent);
+    const rotation = new Quaternion().setFromRotationMatrix(matrix);
+    cps.push(new ControlPoint(position, rotation, 1, i));
+  }
+  // close loop
+  const first = cps[0];
+  cps.push(new ControlPoint(first.pos.clone(), first.orient.clone(), first.pressure, segments));
+  return cps;
+}
+
+function verifyTubeBrush() {
+  const cps = buildCircleControlPoints();
+  const brush = new TubeBrush();
+  brush.BaseSize_PS = 0.05;
+  brush.initBrush({ m_Guid: 'tube-brush' }, TrTransform.identity);
+  for (const cp of cps) {
+    brush.addControlPoint(cp);
+  }
+  const mesh = brush.createMesh();
+  if (!mesh) {
+    throw new Error('TubeBrush returned null mesh');
+  }
+  const radialSegments = brush.pointsInClosedCircle;
+  const radius = brush.BaseSize_LS || 0.01;
+  const positions = mesh.geometry.getAttribute('position');
+  const pos = new Vector3();
+
+  if (positions.count !== cps.length * radialSegments) {
+    throw new Error(`Vertex count ${positions.count} does not match expected ${cps.length * radialSegments}`);
+  }
+
+  let maxError = 0;
+  let minDistFromOrigin = Infinity;
+  for (let i = 0; i < cps.length; i++) {
+    const center = cps[i].pos;
+    for (let j = 0; j < radialSegments; j++) {
+      pos.fromBufferAttribute(positions, i * radialSegments + j);
+      const dist = pos.distanceTo(center);
+      const error = Math.abs(dist - radius);
+      if (error > maxError) maxError = error;
+      const fromOrigin = pos.length();
+      if (fromOrigin < minDistFromOrigin) minDistFromOrigin = fromOrigin;
+    }
+  }
+
+  console.log(`Max radial error: ${maxError}`);
+  console.log(`Closest vertex distance from origin: ${minDistFromOrigin}`);
+
+  if (maxError > 1e-3) {
+    throw new Error('Radial variance exceeds tolerance');
+  }
+  if (minDistFromOrigin < radius * 0.5) {
+    throw new Error('Detected vertex too close to origin');
+  }
+  console.log('TubeBrush geometry passed basic checks');
+}
+
+verifyTubeBrush();

--- a/js/VerifyTubeBrush.js
+++ b/js/VerifyTubeBrush.js
@@ -11,7 +11,8 @@ function buildCircleControlPoints(segments = 16, radius = 1.5) {
     const position = new Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
     const radial = new Vector3(Math.cos(angle), Math.sin(angle), 0);
     const tangent = new Vector3(-Math.sin(angle), Math.cos(angle), 0);
-    const matrix = new Matrix4().makeBasis(radial, new Vector3(0, 0, 1), tangent);
+    const binormal = new Vector3().crossVectors(tangent, radial).normalize();
+    const matrix = new Matrix4().makeBasis(radial, binormal, tangent);
     const rotation = new Quaternion().setFromRotationMatrix(matrix);
     cps.push(new ControlPoint(position, rotation, 1, i));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "open-brush-stroke-gen-js",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "open-brush-stroke-gen-js",
+      "version": "1.0.0",
+      "dependencies": {
+        "three": "^0.164.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.164.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.164.1.tgz",
+      "integrity": "sha512-iC/hUBbl1vzFny7f5GtqzVXYjMJKaTPxiCxXfrvVdBi1Sf+jhd1CAkitiFwC7mIBFCo3MrDLJG97yisoaWig0w==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "open-brush-stroke-gen-js",
+  "version": "1.0.0",
+  "description": "JavaScript utilities ported from Unity C# for three.js",
+  "type": "module",
+  "dependencies": {
+    "three": "^0.164.0"
+  }
+}


### PR DESCRIPTION
## Summary
- remove placeholder SimpleBrush and revert minimal example to line-based placeholder
- introduce BrushDescriptor and BaseBrush scaffolding to mirror C# brush API
- add transform helper utilities and coordinate accessors
- modularize pointer logic and stub stroke lifecycle methods

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/three)*
- `node js/MinimalExample.js` *(fails: Cannot find package 'three')*
- `node -e "import('./js/TransformExtensions.js')"` *(fails: Cannot find package 'three')*
- `node -e "import('./js/Coords.js')"` *(fails: Cannot find package 'three')*
- `node -e "import('./js/Pointer.js')"` *(fails: Cannot find package 'three')*


------
https://chatgpt.com/codex/tasks/task_e_689392e088408331b9352e375c9cf5c4