### PR TITLE
feat: custom tube brush mesh generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Node.js dependencies
+node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # Guidelines for Contributors
 
-- **Port, don't innovate**: Maintain feature parity with the original C# Tilt Brush implementation. Mirror its architecture and logic without introducing new features or redesigns.
-- **Three.js target**: All code should run in JavaScript with three.js; remove Unity-specific constructs as you port.
+ - **Port, don't innovate**: Maintain feature parity with the original C# Tilt Brush implementation. Mirror its architecture and logic without introducing new features or redesigns.
+ - **Match the public interface of the C#**: Classes and functions should expose the same parameters and methods as their C# counterparts; avoid adding options that don't exist in the source.
+ - **Three.js target**: All code should run in JavaScript with three.js; remove Unity-specific constructs as you port.
 - **Always update the demo**: Whenever functionality changes, update `MinimalExample.html` to visually demonstrate the new or modified feature. Include multiple stroke variations and sufficient lighting so normals can be inspected.
 - **Keep strokes verifiable**: Prefer open and closed strokes in examples to expose cross-sections and shape modifiers.
 - **Tests are mandatory**: After code changes, run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Guidelines for Contributors
+
+- **Port, don't innovate**: Maintain feature parity with the original C# Tilt Brush implementation. Mirror its architecture and logic without introducing new features or redesigns.
+- **Three.js target**: All code should run in JavaScript with three.js; remove Unity-specific constructs as you port.
+- **Always update the demo**: Whenever functionality changes, update `MinimalExample.html` to visually demonstrate the new or modified feature. Include multiple stroke variations and sufficient lighting so normals can be inspected.
+- **Keep strokes verifiable**: Prefer open and closed strokes in examples to expose cross-sections and shape modifiers.
+- **Tests are mandatory**: After code changes, run:
+  - `npm install`
+  - `node -e "import('./js/Pointer.js').then(()=>console.log('ok'))"`
+  - `node -e "import('./js/MinimalExample.js').then(()=>console.log('ok'))"`
+  - `node js/VerifyTubeBrush.js`
+  Make a best effort to ensure these commands succeed.
+- **Stub remaining work**: Provide stub implementations for unported C# methods so pending work is explicit.
+- **Repository hygiene**: Keep `node_modules` out of version control and leave the working tree clean after commits.
+
+These instructions apply to the entire repository.

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -43,10 +43,16 @@
     circleSquare.canvas.position.set(2, 0, 0);
 
     const lineRound = createOpenStroke(scene, TubeBrush.CrossSection.ROUND);
-    lineRound.canvas.position.set(0, -2, 0);
+    lineRound.canvas.position.set(-2, 2, 0);
 
     const lineTaper = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.TAPER);
-    lineTaper.canvas.position.set(0, 2, 0);
+    lineTaper.canvas.position.set(2, 2, 0);
+
+    const lineSin = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.SIN);
+    lineSin.canvas.position.set(-2, -2, 0);
+
+    const linePetal = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.PETAL);
+    linePetal.canvas.position.set(2, -2, 0);
 
     const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.z = 5;

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -35,18 +35,23 @@
     dir.position.set(5, 5, 5);
     scene.add(dir);
 
-    // Create four stroke variations: circle/open with round/square cross sections.
+    // Create strokes to showcase cross-sections and shape modifiers.
     const circleRound = createCircleStroke(scene, TubeBrush.CrossSection.ROUND);
     circleRound.canvas.position.set(-2, 0, 0);
 
     const circleSquare = createCircleStroke(scene, TubeBrush.CrossSection.SQUARE);
     circleSquare.canvas.position.set(2, 0, 0);
 
-    const lineRound = createOpenStroke(scene, TubeBrush.CrossSection.ROUND);
-    lineRound.canvas.position.set(0, -2, 0);
+    const lineTaper = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.TAPER);
+    lineTaper.canvas.position.set(0, -2, 0);
 
-    const lineSquare = createOpenStroke(scene, TubeBrush.CrossSection.SQUARE);
-    lineSquare.canvas.position.set(0, 2, 0);
+    const lineOffset = createOpenStroke(
+      scene,
+      TubeBrush.CrossSection.ROUND,
+      TubeBrush.ShapeModifier.SURFACE_OFFSET,
+      0.02
+    );
+    lineOffset.canvas.position.set(0, 2, 0);
 
     const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.z = 5;

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -36,16 +36,16 @@
     scene.add(dir);
 
     // Create four stroke variations: circle/open with round/square cross sections.
-    const circleRound = createCircleStroke(scene, TubeBrush.ShapeModifier.NONE);
+    const circleRound = createCircleStroke(scene, TubeBrush.CrossSection.ROUND);
     circleRound.canvas.position.set(-2, 0, 0);
 
-    const circleSquare = createCircleStroke(scene, TubeBrush.ShapeModifier.SQUARE);
+    const circleSquare = createCircleStroke(scene, TubeBrush.CrossSection.SQUARE);
     circleSquare.canvas.position.set(2, 0, 0);
 
-    const lineRound = createOpenStroke(scene, TubeBrush.ShapeModifier.NONE);
+    const lineRound = createOpenStroke(scene, TubeBrush.CrossSection.ROUND);
     lineRound.canvas.position.set(0, -2, 0);
 
-    const lineSquare = createOpenStroke(scene, TubeBrush.ShapeModifier.SQUARE);
+    const lineSquare = createOpenStroke(scene, TubeBrush.CrossSection.SQUARE);
     lineSquare.canvas.position.set(0, 2, 0);
 
     const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -35,7 +35,7 @@
     dir.position.set(5, 5, 5);
     scene.add(dir);
 
-    // Create strokes to showcase cross-sections and the taper modifier.
+    // Create strokes to showcase cross-sections and shape modifiers.
     const circleRound = createCircleStroke(scene, TubeBrush.CrossSection.ROUND);
     circleRound.canvas.position.set(-2, 0, 0);
 
@@ -45,8 +45,16 @@
     const lineRound = createOpenStroke(scene, TubeBrush.CrossSection.ROUND);
     lineRound.canvas.position.set(0, -2, 0);
 
-    const lineTaper = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.TAPER);
-    lineTaper.canvas.position.set(0, 2, 0);
+      const lineTaper = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.TAPER);
+      lineTaper.canvas.position.set(0, 2, 0);
+
+      const lineOffset = createOpenStroke(
+        scene,
+        TubeBrush.CrossSection.ROUND,
+        TubeBrush.ShapeModifier.SURFACE_OFFSET,
+        0.02
+      );
+      lineOffset.canvas.position.set(0, 0, 0);
 
     const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.z = 5;

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Minimal Stroke Example</title>
+  <style>
+    body { margin: 0; }
+    canvas { display: block; }
+  </style>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.156.1/build/three.module.js",
+        "three/addons/": "https://unpkg.com/three@0.156.1/examples/jsm/"
+      }
+    }
+  </script>
+</head>
+<body>
+  <script type="module">
+    import { Scene, PerspectiveCamera, WebGLRenderer, AmbientLight, DirectionalLight } from 'three';
+    import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+    import { createCircleStroke, createOpenStroke } from './js/MinimalExample.js';
+    import TubeBrush from './js/TubeBrush.js';
+
+    const renderer = new WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    const scene = new Scene();
+
+    const ambient = new AmbientLight(0xffffff, 0.5);
+    scene.add(ambient);
+    const dir = new DirectionalLight(0xffffff, 0.8);
+    dir.position.set(5, 5, 5);
+    scene.add(dir);
+
+    // Create four stroke variations: circle/open with round/square cross sections.
+    const circleRound = createCircleStroke(scene, TubeBrush.ShapeModifier.NONE);
+    circleRound.canvas.position.set(-2, 0, 0);
+
+    const circleSquare = createCircleStroke(scene, TubeBrush.ShapeModifier.SQUARE);
+    circleSquare.canvas.position.set(2, 0, 0);
+
+    const lineRound = createOpenStroke(scene, TubeBrush.ShapeModifier.NONE);
+    lineRound.canvas.position.set(0, -2, 0);
+
+    const lineSquare = createOpenStroke(scene, TubeBrush.ShapeModifier.SQUARE);
+    lineSquare.canvas.position.set(0, 2, 0);
+
+    const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.z = 5;
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    function animate() {
+      requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    }
+    animate();
+  </script>
+</body>
+</html>

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -35,23 +35,18 @@
     dir.position.set(5, 5, 5);
     scene.add(dir);
 
-    // Create strokes to showcase cross-sections and shape modifiers.
+    // Create strokes to showcase cross-sections and the taper modifier.
     const circleRound = createCircleStroke(scene, TubeBrush.CrossSection.ROUND);
     circleRound.canvas.position.set(-2, 0, 0);
 
     const circleSquare = createCircleStroke(scene, TubeBrush.CrossSection.SQUARE);
     circleSquare.canvas.position.set(2, 0, 0);
 
-    const lineTaper = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.TAPER);
-    lineTaper.canvas.position.set(0, -2, 0);
+    const lineRound = createOpenStroke(scene, TubeBrush.CrossSection.ROUND);
+    lineRound.canvas.position.set(0, -2, 0);
 
-    const lineOffset = createOpenStroke(
-      scene,
-      TubeBrush.CrossSection.ROUND,
-      TubeBrush.ShapeModifier.SURFACE_OFFSET,
-      0.02
-    );
-    lineOffset.canvas.position.set(0, 2, 0);
+    const lineTaper = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.TAPER);
+    lineTaper.canvas.position.set(0, 2, 0);
 
     const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.z = 5;

--- a/MinimalExample.html
+++ b/MinimalExample.html
@@ -45,16 +45,8 @@
     const lineRound = createOpenStroke(scene, TubeBrush.CrossSection.ROUND);
     lineRound.canvas.position.set(0, -2, 0);
 
-      const lineTaper = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.TAPER);
-      lineTaper.canvas.position.set(0, 2, 0);
-
-      const lineOffset = createOpenStroke(
-        scene,
-        TubeBrush.CrossSection.ROUND,
-        TubeBrush.ShapeModifier.SURFACE_OFFSET,
-        0.02
-      );
-      lineOffset.canvas.position.set(0, 0, 0);
+    const lineTaper = createOpenStroke(scene, TubeBrush.CrossSection.ROUND, TubeBrush.ShapeModifier.TAPER);
+    lineTaper.canvas.position.set(0, 2, 0);
 
     const camera = new PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.z = 5;

--- a/js/BaseBrush.js
+++ b/js/BaseBrush.js
@@ -1,0 +1,103 @@
+import { Group, Color } from 'three';
+import { TrTransform } from './TrTransform.js';
+
+export class BaseBrush {
+  constructor(canBatch = false) {
+    this.m_bCanBatch = canBatch;
+    this.m_Desc = null;
+    this.m_EnableBackfaces = false;
+    this.m_PreviewMode = false;
+    this.m_IsLoading = false;
+    this.m_Color = new Color();
+    this.m_LastSpawnXf = TrTransform.identity;
+    this.m_BaseSize_PS = 0;
+    this.m_rng = { seed: 0 };
+    this.group = new Group();
+  }
+
+  static create(parent, xfInParentSpace, desc, color, size_PS) {
+    const brush = new BaseBrush();
+    brush.group.name = desc?.Description || desc?.m_DurableName || 'BrushStroke';
+    if (parent && parent.add) {
+      parent.add(brush.group);
+    }
+    brush.m_Desc = desc;
+    brush.m_Color.copy(color);
+    brush.m_BaseSize_PS = size_PS;
+    brush.m_LastSpawnXf = xfInParentSpace;
+    brush.initBrush(desc, xfInParentSpace);
+    return brush;
+  }
+
+  get StrokeScale() {
+    return this.m_LastSpawnXf.scale;
+  }
+
+  get LOCAL_TO_POINTER() {
+    return 1 / this.m_LastSpawnXf.scale;
+  }
+
+  get POINTER_TO_LOCAL() {
+    return this.m_LastSpawnXf.scale;
+  }
+
+  get BaseSize_PS() {
+    return this.m_BaseSize_PS;
+  }
+
+  set BaseSize_PS(v) {
+    this.m_BaseSize_PS = v;
+  }
+
+  get BaseSize_LS() {
+    return this.m_BaseSize_PS * this.POINTER_TO_LOCAL;
+  }
+
+  get Descriptor() {
+    return this.m_Desc;
+  }
+
+  get CurrentColor() {
+    return this.m_Color;
+  }
+
+  get RandomSeed() {
+    return this.m_rng.seed || 0;
+  }
+
+  set RandomSeed(value) {
+    this.m_rng.seed = value;
+  }
+
+  setIsLoading() {
+    this.m_IsLoading = true;
+  }
+
+  setPreviewMode() {
+    this.m_PreviewMode = true;
+  }
+
+  // Stub methods for subclasses to override
+  initBrush(desc, xfInParentSpace) {
+    // TODO: implement brush-specific initialization
+  }
+
+  resetBrushForPreview(unusedXf) {
+    // TODO: reset brush state for preview rendering
+  }
+
+  addControlPoint(cp, pointer, pressure, timestamp) {
+    // TODO: handle control point addition
+  }
+
+  finalizeStroke() {
+    // TODO: finalize stroke geometry
+  }
+
+  getSpawnInterval(pressure01) {
+    // TODO: return how far apart to spawn control points based on pressure
+    return 0;
+  }
+}
+
+export default BaseBrush;

--- a/js/BrushCatalog.js
+++ b/js/BrushCatalog.js
@@ -1,0 +1,78 @@
+// Port of Tilt Brush's BrushCatalog to JavaScript.
+// Manages registration and lookup of BrushDescriptor instances.
+import BrushDescriptor from './BrushDescriptor.js';
+
+export default class BrushCatalog {
+  static m_GlobalNoiseTexture = null;
+  static m_GuidToBrush = new Map();
+  static m_GuiBrushList = [];
+  static m_Manifest = null;
+
+  static GetBrush(guid) {
+    return this.m_GuidToBrush.get(guid) || null;
+  }
+
+  static Init(manifest) {
+    this.m_Manifest = manifest;
+    this.m_GuidToBrush = new Map();
+    this.m_GuiBrushList = [];
+
+    // TODO: Shader.SetGlobalTexture("_GlobalNoiseTexture", m_GlobalNoiseTexture);
+    const manifestBrushes = this.LoadBrushesInManifest();
+
+    for (const brush of manifestBrushes) {
+      const existing = this.m_GuidToBrush.get(brush.m_Guid);
+      if (existing && existing !== brush) {
+        console.error(`Guid collision: ${existing} ${brush}`);
+        continue;
+      }
+      this.m_GuidToBrush.set(brush.m_Guid, brush);
+    }
+
+    // Add reverse links and auto-add compat brushes
+    for (const brush of manifestBrushes) {
+      brush.m_SupersededBy = null;
+    }
+    for (const brush of manifestBrushes) {
+      const older = brush.m_Supersedes;
+      if (!older) continue;
+      if (!this.m_GuidToBrush.has(older.m_Guid)) {
+        this.m_GuidToBrush.set(older.m_Guid, older);
+        older.m_HiddenInGui = true;
+      }
+      if (older.m_SupersededBy && older.m_SupersededBy.name !== brush.name) {
+        console.warn(
+          `Unexpected: ${older.name} is superseded by both ${older.m_SupersededBy.name} and ${brush.name}`
+        );
+      } else {
+        older.m_SupersededBy = brush;
+      }
+    }
+
+    // Postprocess: put brushes into parse-friendly list
+    this.m_GuiBrushList = [];
+    for (const brush of this.m_GuidToBrush.values()) {
+      if (brush.m_HiddenInGui) continue;
+      this.m_GuiBrushList.push(brush);
+    }
+  }
+
+  static LoadBrushesInManifest() {
+    const output = [];
+    if (!this.m_Manifest) return output;
+    const brushes = this.m_Manifest.Brushes || [];
+    for (const desc of brushes) {
+      if (desc) output.push(desc);
+    }
+
+    const compat = this.m_Manifest.CompatibilityBrushes || [];
+    const hidden = compat.filter(desc => !brushes.includes(desc));
+    for (const desc of hidden) {
+      if (desc) {
+        desc.m_HiddenInGui = true;
+        output.push(desc);
+      }
+    }
+    return output;
+  }
+}

--- a/js/BrushDescriptor.js
+++ b/js/BrushDescriptor.js
@@ -1,0 +1,83 @@
+// Port of Tilt Brush's BrushDescriptor ScriptableObject to JavaScript.
+// Fields mirror the C# version to aid in porting brush metadata.
+
+export default class BrushDescriptor {
+  constructor() {
+    // Identity
+    this.m_Guid = '';
+    this.m_DurableName = '';
+    this.m_CreationVersion = '';
+    this.m_ShaderVersion = '10.0';
+    this.m_BrushPrefab = null;
+    this.m_Tags = ['default'];
+    this.m_Nondeterministic = false;
+    this.m_Supersedes = null;
+    this.m_SupersededBy = null; // set during catalog init
+    this.m_LooksIdentical = false;
+
+    // GUI
+    this.m_ButtonTexture = null;
+    this.m_LocalizedDescription = null; // stub for Unity LocalizedString
+    this.m_DescriptionExtra = '';
+    this.m_HiddenInGui = false;
+
+    // Material
+    this.m_Material = null;
+    this.m_TextureAtlasV = 1;
+    this.m_TileRate = 1;
+
+    // Size
+    this.m_BrushSizeRange = [0, 0];
+    this.m_PressureSizeRange = [0.1, 1];
+    this.m_SizeVariance = 0;
+    this.m_PreviewPressureSizeMin = 0.001;
+
+    // Color
+    this.m_Opacity = 1;
+    this.m_PressureOpacityRange = [0, 1];
+    this.m_ColorLuminanceMin = 0;
+    this.m_ColorSaturationMax = 1;
+
+    // Particle
+    this.m_ParticleSpeed = 0;
+    this.m_ParticleRate = 0;
+    this.m_ParticleInitialRotationRange = 0;
+    this.m_RandomizeAlpha = false;
+
+    // QuadBatch
+    this.m_SprayRateMultiplier = 0;
+    this.m_RotationVariance = 0;
+    this.m_PositionVariance = 0;
+    this.m_SizeRatio = [1, 1];
+
+    // Geometry Brush
+    this.m_M11Compatibility = false;
+
+    // Tube
+    this.m_SolidMinLengthMeters_PS = 0.002;
+    this.m_TubeStoreRadiusInTexcoord0Z = false;
+
+    // Misc
+    this.m_RenderBackfaces = false;
+    this.m_BackIsInvisible = false;
+    this.m_BackfaceHueShift = 0;
+    this.m_BoundsPadding = 0;
+  }
+
+  get Description() {
+    // LocalizedString stub: use durable name if no localized string
+    return this.m_LocalizedDescription || this.m_DurableName;
+  }
+
+  get Material() {
+    return this.m_Material;
+  }
+
+  PressureSizeMin(previewMode) {
+    return previewMode ? this.m_PreviewPressureSizeMin : this.m_PressureSizeRange[0];
+  }
+
+  toString() {
+    return `BrushDescriptor<${this.m_DurableName} ${this.m_Guid}>`;
+  }
+}

--- a/js/BrushManifest.js
+++ b/js/BrushManifest.js
@@ -1,0 +1,20 @@
+// Port of Tilt Brush's BrushManifest ScriptableObject to JavaScript.
+// Holds the list of available brushes and compatibility brushes.
+export default class BrushManifest {
+  constructor() {
+    // Array of BrushDescriptor
+    this.Brushes = [];
+    // Array of BrushDescriptor that are hidden but still loadable
+    this.CompatibilityBrushes = [];
+  }
+
+  // Create a manifest from a plain JSON object
+  static fromJSON(json) {
+    const manifest = new BrushManifest();
+    if (json) {
+      manifest.Brushes = json.Brushes ? Array.from(json.Brushes) : [];
+      manifest.CompatibilityBrushes = json.CompatibilityBrushes ? Array.from(json.CompatibilityBrushes) : [];
+    }
+    return manifest;
+  }
+}

--- a/js/ControlPoint.js
+++ b/js/ControlPoint.js
@@ -1,0 +1,12 @@
+import { Vector3, Quaternion } from 'three';
+
+export class ControlPoint {
+  constructor(pos = new Vector3(), orient = new Quaternion(), pressure = 0, timestampMs = 0) {
+    this.pos = pos;
+    this.orient = orient;
+    this.pressure = pressure;
+    this.timestampMs = timestampMs;
+  }
+}
+
+export default ControlPoint;

--- a/js/Coords.js
+++ b/js/Coords.js
@@ -1,0 +1,12 @@
+import { GlobalAccessor, LocalAccessor, RelativeAccessor } from './TransformExtensions.js';
+
+/**
+ * Coordinate system helpers mirroring Tilt Brush's Coords class.
+ * AsRoom and AsCanvas are placeholders until full scene infrastructure exists.
+ */
+export default class Coords {}
+
+Coords.AsRoom = undefined; // TODO: define room-space accessor
+Coords.AsGlobal = new GlobalAccessor();
+Coords.AsLocal = new LocalAccessor();
+Coords.AsCanvas = undefined; // Deprecated; provided by canvas instances

--- a/js/GeometryBrush.js
+++ b/js/GeometryBrush.js
@@ -1,0 +1,55 @@
+import { BaseBrush } from './BaseBrush.js';
+
+// Simplified port of Tilt Brush's GeometryBrush base class.
+// Handles control-point collection and delegates mesh creation to subclasses.
+export class GeometryBrush extends BaseBrush {
+  constructor({ canBatch = true, upperBoundVertsPerKnot = 0, doubleSided = false } = {}) {
+    super(canBatch);
+    this.m_UpperBoundVertsPerKnot = upperBoundVertsPerKnot;
+    this.m_bDoubleSided = doubleSided;
+    this.controlPoints = [];
+    this.mesh = null;
+  }
+
+  initBrush(desc, localPointerXf) {
+    super.initBrush(desc, localPointerXf);
+    this.controlPoints.length = 0;
+  }
+
+  resetBrushForPreview(unusedXf) {
+    super.resetBrushForPreview(unusedXf);
+    this.controlPoints.length = 0;
+    if (this.mesh) {
+      this.group.remove(this.mesh);
+      this.mesh.geometry.dispose();
+      this.mesh.material.dispose();
+      this.mesh = null;
+    }
+  }
+
+  // Store control points for later geometry generation.
+  addControlPoint(cp) {
+    this.controlPoints.push(cp);
+  }
+
+  // Subclasses should override to build their specific mesh.
+  createMesh() {
+    // TODO: implement in subclasses
+    return null;
+  }
+
+  finalizeStroke() {
+    if (this.mesh) {
+      this.group.remove(this.mesh);
+      this.mesh.geometry.dispose();
+      this.mesh.material.dispose();
+    }
+    const mesh = this.createMesh();
+    if (mesh) {
+      this.mesh = mesh;
+      this.group.add(mesh);
+    }
+  }
+}
+
+export default GeometryBrush;

--- a/js/HSLColor.js
+++ b/js/HSLColor.js
@@ -1,0 +1,121 @@
+import { Color } from 'three';
+
+function colorCalc(c, t1, t2) {
+  if (c < 0) {
+    c += 6;
+  } else if (c >= 6) {
+    c -= 6;
+  }
+  if (c < 1) return t1 + (t2 - t1) * c;
+  if (c < 3) return t2;
+  if (c < 4) return t1 + (t2 - t1) * (4 - c);
+  return t1;
+}
+
+export class HSLColor {
+  static HUE_MAX = 6;
+
+  constructor(h = 0, s = 0, l = 0, a = 1) {
+    h = h % HSLColor.HUE_MAX;
+    if (h < 0) h += HSLColor.HUE_MAX;
+    this.h = h;
+    this.s = s;
+    this.l = l;
+    this.a = a;
+  }
+
+  get hueDegrees() {
+    return this.h * (360 / HSLColor.HUE_MAX);
+  }
+
+  set hueDegrees(value) {
+    value = ((value * HSLColor.HUE_MAX) / 360) % HSLColor.HUE_MAX;
+    if (value < 0) value += HSLColor.HUE_MAX;
+    this.h = value;
+  }
+
+  get hue01() {
+    return this.h * (1 / HSLColor.HUE_MAX);
+  }
+
+  set hue01(value) {
+    value = (value * HSLColor.HUE_MAX) % HSLColor.HUE_MAX;
+    if (value < 0) value += HSLColor.HUE_MAX;
+    this.h = value;
+  }
+
+  toColor() {
+    if (this.s === 0) {
+      const gray = new Color(this.l, this.l, this.l);
+      return { color: gray, a: this.a };
+    }
+    let t2;
+    if (this.l < 0.5) {
+      t2 = this.l * (1 + this.s);
+    } else {
+      t2 = this.l + this.s - this.l * this.s;
+    }
+    const t1 = 2 * this.l - t2;
+    const th = this.h * (6 / HSLColor.HUE_MAX);
+    const tr = th + 2;
+    const tg = th;
+    const tb = th - 2;
+    const color = new Color(
+      colorCalc(tr, t1, t2),
+      colorCalc(tg, t1, t2),
+      colorCalc(tb, t1, t2)
+    );
+    return { color, a: this.a };
+  }
+
+  static fromColor(color, a = 1) {
+    const r = color.r;
+    const g = color.g;
+    const b = color.b;
+    const min = Math.min(r, g, b);
+    const max = Math.max(r, g, b);
+    const delta = max - min;
+    let h = 0;
+    let s = 0;
+    const l = (max + min) * 0.5;
+    if (delta !== 0) {
+      if (l < 0.5) {
+        s = delta / (max + min);
+      } else {
+        s = delta / (2 - max - min);
+      }
+      if (r === max) {
+        h = (g - b) / delta;
+      } else if (g === max) {
+        h = 2 + (b - r) / delta;
+      } else {
+        h = 4 + (r - g) / delta;
+      }
+    }
+    h *= HSLColor.HUE_MAX / 6;
+    return new HSLColor(h, s, l, a);
+  }
+
+  static fromHSV(h, s, v, a = 1) {
+    h = h % HSLColor.HUE_MAX;
+    if (h < 0) h += HSLColor.HUE_MAX;
+    const l = v - 0.5 * s * v;
+    let s2;
+    if (l <= 0.5) {
+      s2 = s / (2 - s);
+    } else {
+      s2 = (s * v) / (2 * (1 - v) + s * v);
+    }
+    return new HSLColor(h, s2, l, a);
+  }
+
+  getBaseColor() {
+    return new HSLColor(this.h, this.s, 0.5, this.a);
+  }
+
+  toString() {
+    return `HSLA(${this.h.toFixed(3)}, ${this.s.toFixed(3)}, ${this.l.toFixed(3)}, ${this.a.toFixed(3)})`;
+  }
+}
+
+export default HSLColor;

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -16,7 +16,7 @@ tubeDesc.m_BrushPrefab = TubeBrush;
 const manifest = BrushManifest.fromJSON({ Brushes: [tubeDesc], CompatibilityBrushes: [] });
 BrushCatalog.Init(manifest);
 
-function buildStroke(scene, controlPoints, crossSection, shapeMod, surfaceOffset = 0) {
+function buildStroke(scene, controlPoints, crossSection, shapeMod) {
   const canvas = new Group();
   scene.add(canvas);
 
@@ -27,7 +27,6 @@ function buildStroke(scene, controlPoints, crossSection, shapeMod, surfaceOffset
   stroke.brushSize = 0.05;
   stroke.crossSection = crossSection;
   stroke.shapeModifier = shapeMod;
-  stroke.surfaceOffset = surfaceOffset;
 
   const pointer = new Pointer(canvas);
   pointer.recreateLineFromMemory(stroke);
@@ -40,8 +39,7 @@ function buildStroke(scene, controlPoints, crossSection, shapeMod, surfaceOffset
 export function createCircleStroke(
   scene,
   crossSection = TubeBrush.CrossSection.ROUND,
-  shapeMod = TubeBrush.ShapeModifier.NONE,
-  surfaceOffset = 0
+  shapeMod = TubeBrush.ShapeModifier.NONE
 ) {
   const controlPoints = [];
   const segments = 32;
@@ -61,14 +59,13 @@ export function createCircleStroke(
   const first = controlPoints[0];
   controlPoints.push(new ControlPoint(first.pos.clone(), first.orient.clone(), first.pressure, segments));
 
-  return buildStroke(scene, controlPoints, crossSection, shapeMod, surfaceOffset);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod);
 }
 
 export function createOpenStroke(
   scene,
   crossSection = TubeBrush.CrossSection.ROUND,
-  shapeMod = TubeBrush.ShapeModifier.NONE,
-  surfaceOffset = 0
+  shapeMod = TubeBrush.ShapeModifier.NONE
 ) {
   const positions = [new Vector3(-1, 0, 0), new Vector3(1, 0, 0)];
   const radial = new Vector3(0, 1, 0);
@@ -78,5 +75,5 @@ export function createOpenStroke(
   const rotation = new Quaternion().setFromRotationMatrix(matrix);
 
   const controlPoints = positions.map((pos, idx) => new ControlPoint(pos, rotation.clone(), 1, idx));
-  return buildStroke(scene, controlPoints, crossSection, shapeMod, surfaceOffset);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod);
 }

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -16,17 +16,17 @@ tubeDesc.m_BrushPrefab = TubeBrush;
 const manifest = BrushManifest.fromJSON({ Brushes: [tubeDesc], CompatibilityBrushes: [] });
 BrushCatalog.Init(manifest);
 
-function buildStroke(scene, controlPoints, shape, silhouette) {
+function buildStroke(scene, controlPoints, crossSection, shapeMod) {
   const canvas = new Group();
   scene.add(canvas);
 
   const stroke = new Stroke();
   stroke.controlPoints = controlPoints;
-  stroke.color = new Color(shape === TubeBrush.ShapeModifier.SQUARE ? 'red' : 'blue');
+  stroke.color = new Color(crossSection === TubeBrush.CrossSection.SQUARE ? 'red' : 'blue');
   stroke.brushGuid = 'tube-brush';
   stroke.brushSize = 0.05;
-  stroke.shapeModifier = shape;
-  stroke.silhouetteModifier = silhouette;
+  stroke.crossSection = crossSection;
+  stroke.shapeModifier = shapeMod;
 
   const pointer = new Pointer(canvas);
   pointer.recreateLineFromMemory(stroke);
@@ -38,8 +38,8 @@ function buildStroke(scene, controlPoints, shape, silhouette) {
 
 export function createCircleStroke(
   scene,
-  shape = TubeBrush.ShapeModifier.NONE,
-  silhouette = TubeBrush.SilhouetteModifier.NONE
+  crossSection = TubeBrush.CrossSection.ROUND,
+  shapeMod = TubeBrush.ShapeModifier.NONE
 ) {
   const controlPoints = [];
   const segments = 32;
@@ -59,13 +59,13 @@ export function createCircleStroke(
   const first = controlPoints[0];
   controlPoints.push(new ControlPoint(first.pos.clone(), first.orient.clone(), first.pressure, segments));
 
-  return buildStroke(scene, controlPoints, shape, silhouette);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod);
 }
 
 export function createOpenStroke(
   scene,
-  shape = TubeBrush.ShapeModifier.NONE,
-  silhouette = TubeBrush.SilhouetteModifier.NONE
+  crossSection = TubeBrush.CrossSection.ROUND,
+  shapeMod = TubeBrush.ShapeModifier.NONE
 ) {
   const positions = [new Vector3(-1, 0, 0), new Vector3(1, 0, 0)];
   const radial = new Vector3(0, 1, 0);
@@ -75,5 +75,5 @@ export function createOpenStroke(
   const rotation = new Quaternion().setFromRotationMatrix(matrix);
 
   const controlPoints = positions.map((pos, idx) => new ControlPoint(pos, rotation.clone(), 1, idx));
-  return buildStroke(scene, controlPoints, shape, silhouette);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod);
 }

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -16,7 +16,7 @@ tubeDesc.m_BrushPrefab = TubeBrush;
 const manifest = BrushManifest.fromJSON({ Brushes: [tubeDesc], CompatibilityBrushes: [] });
 BrushCatalog.Init(manifest);
 
-function buildStroke(scene, controlPoints, crossSection, shapeMod, offset = 0) {
+function buildStroke(scene, controlPoints, crossSection, shapeMod) {
   const canvas = new Group();
   scene.add(canvas);
 
@@ -27,9 +27,6 @@ function buildStroke(scene, controlPoints, crossSection, shapeMod, offset = 0) {
   stroke.brushSize = 0.05;
   stroke.crossSection = crossSection;
   stroke.shapeModifier = shapeMod;
-  if (shapeMod === TubeBrush.ShapeModifier.SURFACE_OFFSET) {
-    stroke.surfaceOffset = offset;
-  }
 
   const pointer = new Pointer(canvas);
   pointer.recreateLineFromMemory(stroke);
@@ -42,8 +39,7 @@ function buildStroke(scene, controlPoints, crossSection, shapeMod, offset = 0) {
 export function createCircleStroke(
   scene,
   crossSection = TubeBrush.CrossSection.ROUND,
-  shapeMod = TubeBrush.ShapeModifier.NONE,
-  offset = 0
+  shapeMod = TubeBrush.ShapeModifier.NONE
 ) {
   const controlPoints = [];
   const segments = 32;
@@ -63,14 +59,13 @@ export function createCircleStroke(
   const first = controlPoints[0];
   controlPoints.push(new ControlPoint(first.pos.clone(), first.orient.clone(), first.pressure, segments));
 
-  return buildStroke(scene, controlPoints, crossSection, shapeMod, offset);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod);
 }
 
 export function createOpenStroke(
   scene,
   crossSection = TubeBrush.CrossSection.ROUND,
-  shapeMod = TubeBrush.ShapeModifier.NONE,
-  offset = 0
+  shapeMod = TubeBrush.ShapeModifier.NONE
 ) {
   const positions = [new Vector3(-1, 0, 0), new Vector3(1, 0, 0)];
   const radial = new Vector3(0, 1, 0);
@@ -80,5 +75,5 @@ export function createOpenStroke(
   const rotation = new Quaternion().setFromRotationMatrix(matrix);
 
   const controlPoints = positions.map((pos, idx) => new ControlPoint(pos, rotation.clone(), 1, idx));
-  return buildStroke(scene, controlPoints, crossSection, shapeMod, offset);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod);
 }

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -16,7 +16,7 @@ tubeDesc.m_BrushPrefab = TubeBrush;
 const manifest = BrushManifest.fromJSON({ Brushes: [tubeDesc], CompatibilityBrushes: [] });
 BrushCatalog.Init(manifest);
 
-function buildStroke(scene, controlPoints, crossSection, shapeMod) {
+function buildStroke(scene, controlPoints, crossSection, shapeMod, surfaceOffset = 0) {
   const canvas = new Group();
   scene.add(canvas);
 
@@ -27,6 +27,7 @@ function buildStroke(scene, controlPoints, crossSection, shapeMod) {
   stroke.brushSize = 0.05;
   stroke.crossSection = crossSection;
   stroke.shapeModifier = shapeMod;
+  stroke.surfaceOffset = surfaceOffset;
 
   const pointer = new Pointer(canvas);
   pointer.recreateLineFromMemory(stroke);
@@ -39,7 +40,8 @@ function buildStroke(scene, controlPoints, crossSection, shapeMod) {
 export function createCircleStroke(
   scene,
   crossSection = TubeBrush.CrossSection.ROUND,
-  shapeMod = TubeBrush.ShapeModifier.NONE
+  shapeMod = TubeBrush.ShapeModifier.NONE,
+  surfaceOffset = 0
 ) {
   const controlPoints = [];
   const segments = 32;
@@ -59,13 +61,14 @@ export function createCircleStroke(
   const first = controlPoints[0];
   controlPoints.push(new ControlPoint(first.pos.clone(), first.orient.clone(), first.pressure, segments));
 
-  return buildStroke(scene, controlPoints, crossSection, shapeMod);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod, surfaceOffset);
 }
 
 export function createOpenStroke(
   scene,
   crossSection = TubeBrush.CrossSection.ROUND,
-  shapeMod = TubeBrush.ShapeModifier.NONE
+  shapeMod = TubeBrush.ShapeModifier.NONE,
+  surfaceOffset = 0
 ) {
   const positions = [new Vector3(-1, 0, 0), new Vector3(1, 0, 0)];
   const radial = new Vector3(0, 1, 0);
@@ -75,5 +78,5 @@ export function createOpenStroke(
   const rotation = new Quaternion().setFromRotationMatrix(matrix);
 
   const controlPoints = positions.map((pos, idx) => new ControlPoint(pos, rotation.clone(), 1, idx));
-  return buildStroke(scene, controlPoints, crossSection, shapeMod);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod, surfaceOffset);
 }

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -16,7 +16,7 @@ tubeDesc.m_BrushPrefab = TubeBrush;
 const manifest = BrushManifest.fromJSON({ Brushes: [tubeDesc], CompatibilityBrushes: [] });
 BrushCatalog.Init(manifest);
 
-function buildStroke(scene, controlPoints, crossSection, shapeMod) {
+function buildStroke(scene, controlPoints, crossSection, shapeMod, offset = 0) {
   const canvas = new Group();
   scene.add(canvas);
 
@@ -27,6 +27,9 @@ function buildStroke(scene, controlPoints, crossSection, shapeMod) {
   stroke.brushSize = 0.05;
   stroke.crossSection = crossSection;
   stroke.shapeModifier = shapeMod;
+  if (shapeMod === TubeBrush.ShapeModifier.SURFACE_OFFSET) {
+    stroke.surfaceOffset = offset;
+  }
 
   const pointer = new Pointer(canvas);
   pointer.recreateLineFromMemory(stroke);
@@ -39,7 +42,8 @@ function buildStroke(scene, controlPoints, crossSection, shapeMod) {
 export function createCircleStroke(
   scene,
   crossSection = TubeBrush.CrossSection.ROUND,
-  shapeMod = TubeBrush.ShapeModifier.NONE
+  shapeMod = TubeBrush.ShapeModifier.NONE,
+  offset = 0
 ) {
   const controlPoints = [];
   const segments = 32;
@@ -59,13 +63,14 @@ export function createCircleStroke(
   const first = controlPoints[0];
   controlPoints.push(new ControlPoint(first.pos.clone(), first.orient.clone(), first.pressure, segments));
 
-  return buildStroke(scene, controlPoints, crossSection, shapeMod);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod, offset);
 }
 
 export function createOpenStroke(
   scene,
   crossSection = TubeBrush.CrossSection.ROUND,
-  shapeMod = TubeBrush.ShapeModifier.NONE
+  shapeMod = TubeBrush.ShapeModifier.NONE,
+  offset = 0
 ) {
   const positions = [new Vector3(-1, 0, 0), new Vector3(1, 0, 0)];
   const radial = new Vector3(0, 1, 0);
@@ -75,5 +80,5 @@ export function createOpenStroke(
   const rotation = new Quaternion().setFromRotationMatrix(matrix);
 
   const controlPoints = positions.map((pos, idx) => new ControlPoint(pos, rotation.clone(), 1, idx));
-  return buildStroke(scene, controlPoints, crossSection, shapeMod);
+  return buildStroke(scene, controlPoints, crossSection, shapeMod, offset);
 }

--- a/js/MinimalExample.js
+++ b/js/MinimalExample.js
@@ -1,0 +1,79 @@
+import { Group, Vector3, Quaternion, Color, Matrix4 } from 'three';
+import { ControlPoint } from './ControlPoint.js';
+import BrushCatalog from './BrushCatalog.js';
+import BrushDescriptor from './BrushDescriptor.js';
+import BrushManifest from './BrushManifest.js';
+import { Pointer } from './Pointer.js';
+import { Stroke } from './Stroke.js';
+import TubeBrush from './TubeBrush.js';
+
+// Initialize the brush catalog with TubeBrush once.
+const tubeDesc = new BrushDescriptor();
+tubeDesc.m_Guid = 'tube-brush';
+tubeDesc.m_DurableName = 'TubeBrush';
+tubeDesc.m_LocalizedDescription = 'Tube Brush';
+tubeDesc.m_BrushPrefab = TubeBrush;
+const manifest = BrushManifest.fromJSON({ Brushes: [tubeDesc], CompatibilityBrushes: [] });
+BrushCatalog.Init(manifest);
+
+function buildStroke(scene, controlPoints, shape, silhouette) {
+  const canvas = new Group();
+  scene.add(canvas);
+
+  const stroke = new Stroke();
+  stroke.controlPoints = controlPoints;
+  stroke.color = new Color(shape === TubeBrush.ShapeModifier.SQUARE ? 'red' : 'blue');
+  stroke.brushGuid = 'tube-brush';
+  stroke.brushSize = 0.05;
+  stroke.shapeModifier = shape;
+  stroke.silhouetteModifier = silhouette;
+
+  const pointer = new Pointer(canvas);
+  pointer.recreateLineFromMemory(stroke);
+
+  console.log(`Created TubeBrush stroke with ${stroke.controlPoints.length} control points`);
+
+  return { canvas, stroke };
+}
+
+export function createCircleStroke(
+  scene,
+  shape = TubeBrush.ShapeModifier.NONE,
+  silhouette = TubeBrush.SilhouetteModifier.NONE
+) {
+  const controlPoints = [];
+  const segments = 32;
+  const radius = 1.5;
+  for (let i = 0; i < segments; i++) {
+    const angle = (i * 2 * Math.PI) / segments;
+    const position = new Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
+    const radial = new Vector3(Math.cos(angle), Math.sin(angle), 0);
+    const tangent = new Vector3(-Math.sin(angle), Math.cos(angle), 0);
+    const binormal = new Vector3().crossVectors(tangent, radial).normalize();
+    const matrix = new Matrix4().makeBasis(radial, binormal, tangent);
+    const rotation = new Quaternion().setFromRotationMatrix(matrix);
+    const cp = new ControlPoint(position, rotation, 1, i);
+    controlPoints.push(cp);
+  }
+  // Close the loop by repeating the first control point at the end.
+  const first = controlPoints[0];
+  controlPoints.push(new ControlPoint(first.pos.clone(), first.orient.clone(), first.pressure, segments));
+
+  return buildStroke(scene, controlPoints, shape, silhouette);
+}
+
+export function createOpenStroke(
+  scene,
+  shape = TubeBrush.ShapeModifier.NONE,
+  silhouette = TubeBrush.SilhouetteModifier.NONE
+) {
+  const positions = [new Vector3(-1, 0, 0), new Vector3(1, 0, 0)];
+  const radial = new Vector3(0, 1, 0);
+  const tangent = new Vector3(1, 0, 0);
+  const binormal = new Vector3().crossVectors(tangent, radial).normalize();
+  const matrix = new Matrix4().makeBasis(radial, binormal, tangent);
+  const rotation = new Quaternion().setFromRotationMatrix(matrix);
+
+  const controlPoints = positions.map((pos, idx) => new ControlPoint(pos, rotation.clone(), 1, idx));
+  return buildStroke(scene, controlPoints, shape, silhouette);
+}

--- a/js/Pointer.js
+++ b/js/Pointer.js
@@ -30,6 +30,12 @@ export class Pointer {
     if (stroke.shapeModifier) {
       this.currentBrush.shapeModifier = stroke.shapeModifier;
     }
+    if (stroke.surfaceOffset !== undefined) {
+      this.currentBrush.surfaceOffset = stroke.surfaceOffset;
+    }
+    if (stroke.taperScalar !== undefined) {
+      this.currentBrush.taperScalar = stroke.taperScalar;
+    }
     this.currentBrush.initBrush(desc, TrTransform.identity);
     this.currentStroke = stroke;
     this.currentStroke.controlPoints = this.currentStroke.controlPoints || [];

--- a/js/Pointer.js
+++ b/js/Pointer.js
@@ -24,11 +24,11 @@ export class Pointer {
       this.currentBrush.m_Color.copy(stroke.color);
     }
     this.currentBrush.BaseSize_PS = stroke.brushSize || 0.01;
+    if (stroke.crossSection) {
+      this.currentBrush.crossSection = stroke.crossSection;
+    }
     if (stroke.shapeModifier) {
       this.currentBrush.shapeModifier = stroke.shapeModifier;
-    }
-    if (stroke.silhouetteModifier) {
-      this.currentBrush.silhouetteModifier = stroke.silhouetteModifier;
     }
     this.currentBrush.initBrush(desc, TrTransform.identity);
     this.currentStroke = stroke;

--- a/js/Pointer.js
+++ b/js/Pointer.js
@@ -1,0 +1,79 @@
+import { StrokeType } from './Stroke.js';
+import { TrTransform } from './TrTransform.js';
+import BrushCatalog from './BrushCatalog.js';
+
+export class Pointer {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.currentBrush = null;
+    this.currentStroke = null;
+  }
+
+  /**
+  * Begin a stroke using the provided Stroke data. The stroke should have
+  * brushGuid, color, brushSize, and optional brushScale fields populated.
+  */
+  beginStroke(stroke) {
+    const desc = BrushCatalog.GetBrush(stroke.brushGuid);
+    if (!desc || !desc.m_BrushPrefab) {
+      console.error(`No brush prefab for guid ${stroke.brushGuid}`);
+      return;
+    }
+    this.currentBrush = new desc.m_BrushPrefab();
+    if (stroke.color) {
+      this.currentBrush.m_Color.copy(stroke.color);
+    }
+    this.currentBrush.BaseSize_PS = stroke.brushSize || 0.01;
+    if (stroke.shapeModifier) {
+      this.currentBrush.shapeModifier = stroke.shapeModifier;
+    }
+    if (stroke.silhouetteModifier) {
+      this.currentBrush.silhouetteModifier = stroke.silhouetteModifier;
+    }
+    this.currentBrush.initBrush(desc, TrTransform.identity);
+    this.currentStroke = stroke;
+    this.currentStroke.controlPoints = this.currentStroke.controlPoints || [];
+  }
+
+  /** Add a control point to the active stroke. */
+  updateStroke(controlPoint) {
+    if (!this.currentBrush || !this.currentStroke) return;
+    this.currentBrush.addControlPoint(controlPoint);
+    this.currentStroke.controlPoints.push(controlPoint);
+  }
+
+  /** Finalize the active stroke and add its mesh to the canvas. */
+  endStroke() {
+    if (!this.currentBrush || !this.currentStroke) return null;
+
+    this.currentBrush.finalizeStroke();
+    this.canvas.add(this.currentBrush.group);
+
+    const brushRef = this.currentBrush;
+    const stroke = this.currentStroke;
+    stroke.object = {
+      canvas: this.canvas,
+      hideBrush: hide => {
+        brushRef.group.visible = !hide;
+      },
+      setParent: parent => {
+        parent.add(brushRef.group);
+        this.canvas = parent;
+      },
+    };
+    stroke.type = StrokeType.BrushStroke;
+
+    this.currentBrush = null;
+    this.currentStroke = null;
+    return stroke;
+  }
+
+  /** Recreate a stroke's mesh from stored control points. */
+  recreateLineFromMemory(stroke) {
+    this.beginStroke(stroke);
+    for (const cp of stroke.controlPoints) {
+      this.currentBrush.addControlPoint(cp);
+    }
+    return this.endStroke();
+  }
+}

--- a/js/Pointer.js
+++ b/js/Pointer.js
@@ -30,9 +30,6 @@ export class Pointer {
     if (stroke.shapeModifier) {
       this.currentBrush.shapeModifier = stroke.shapeModifier;
     }
-    if (stroke.surfaceOffset !== undefined) {
-      this.currentBrush.surfaceOffset = stroke.surfaceOffset;
-    }
     this.currentBrush.initBrush(desc, TrTransform.identity);
     this.currentStroke = stroke;
     this.currentStroke.controlPoints = this.currentStroke.controlPoints || [];

--- a/js/Pointer.js
+++ b/js/Pointer.js
@@ -30,12 +30,6 @@ export class Pointer {
     if (stroke.shapeModifier) {
       this.currentBrush.shapeModifier = stroke.shapeModifier;
     }
-    if (stroke.surfaceOffset !== undefined) {
-      this.currentBrush.surfaceOffset = stroke.surfaceOffset;
-    }
-    if (stroke.taperScalar !== undefined) {
-      this.currentBrush.taperScalar = stroke.taperScalar;
-    }
     this.currentBrush.initBrush(desc, TrTransform.identity);
     this.currentStroke = stroke;
     this.currentStroke.controlPoints = this.currentStroke.controlPoints || [];

--- a/js/Pointer.js
+++ b/js/Pointer.js
@@ -30,6 +30,9 @@ export class Pointer {
     if (stroke.shapeModifier) {
       this.currentBrush.shapeModifier = stroke.shapeModifier;
     }
+    if (stroke.surfaceOffset !== undefined) {
+      this.currentBrush.surfaceOffset = stroke.surfaceOffset;
+    }
     this.currentBrush.initBrush(desc, TrTransform.identity);
     this.currentStroke = stroke;
     this.currentStroke.controlPoints = this.currentStroke.controlPoints || [];

--- a/js/QuaternionExtensions.js
+++ b/js/QuaternionExtensions.js
@@ -1,0 +1,85 @@
+import { Quaternion, Vector3 } from 'three';
+
+/**
+ * Utilities mirroring Tilt Brush's QuaternionExtensions.
+ */
+export default class QuaternionExtensions {
+  /**
+   * Creates a quaternion rotating by `angle` radians around `axis`.
+   */
+  static angleAxisRad(angle, axis) {
+    const q = new Quaternion();
+    q.setFromAxisAngle(axis, angle);
+    return q;
+  }
+
+  /**
+   * Quaternion logarithm; returns a quaternion whose xyz represent half-angle.
+   * The input must be unit-length.
+   */
+  static log(q) {
+    const vecLenSq = q.x * q.x + q.y * q.y + q.z * q.z;
+    const lenSq = vecLenSq + q.w * q.w;
+    if (Math.abs(lenSq - 1) > 3e-3) {
+      throw new Error('Quaternion must be unit');
+    }
+
+    const sinTheta = Math.sqrt(vecLenSq);
+    const theta = Math.atan2(sinTheta, q.w);
+
+    if (sinTheta < 1e-5) {
+      if (q.w > 0) {
+        return new Quaternion(q.x, q.y, q.z, 0);
+      }
+      const axis = new Vector3(q.x, q.y, q.z).normalize();
+      if (axis.lengthSq() === 0) axis.set(0, 1, 0);
+      axis.multiplyScalar(theta);
+      return new Quaternion(axis.x, axis.y, axis.z, 0);
+    } else {
+      const k = theta / sinTheta;
+      return new Quaternion(k * q.x, k * q.y, k * q.z, 0);
+    }
+  }
+
+  /**
+   * Quaternion exponentiation; input must have w === 0.
+   */
+  static exp(q) {
+    if (q.w !== 0) {
+      throw new Error('Quaternion must be pure (w=0)');
+    }
+    const v = new Vector3(q.x, q.y, q.z);
+    const vLen = v.length();
+    let sinVOverV;
+    if (vLen < 1e-4) {
+      sinVOverV = vLen;
+    } else {
+      sinVOverV = Math.sin(vLen) / vLen;
+    }
+
+    v.multiplyScalar(sinVOverV);
+    return new Quaternion(v.x, v.y, v.z, Math.cos(vLen));
+  }
+
+  /**
+   * Returns the negated quaternion.
+   */
+  static negated(q) {
+    return new Quaternion(-q.x, -q.y, -q.z, -q.w);
+  }
+
+  /**
+   * Returns the imaginary component of the quaternion.
+   */
+  static im(q) {
+    return new Vector3(q.x, q.y, q.z);
+  }
+
+  /**
+   * Returns the inverse without assuming unit-length.
+   */
+  static trueInverse(q) {
+    const f = 1 / q.lengthSq();
+    return new Quaternion(-q.x * f, -q.y * f, -q.z * f, q.w * f);
+  }
+}

--- a/js/Stroke.js
+++ b/js/Stroke.js
@@ -1,0 +1,148 @@
+import { Vector3, Quaternion } from 'three';
+import { StrokeData } from './StrokeData.js';
+
+export const StrokeType = Object.freeze({
+  NotCreated: 0,
+  BrushStroke: 1,
+  BatchedBrushStroke: 2,
+});
+
+/**
+ * Port of Tilt Brush's Stroke class. Handles stroke metadata and basic
+ * transformation logic without any Unity-specific rendering code.
+ */
+export class Stroke extends StrokeData {
+  constructor(existing = null) {
+    super(existing);
+    this.type = StrokeType.NotCreated;
+    this.intendedCanvas = null;
+    this.object = null;
+    this.copyForSaveThread = null;
+    this.controlPointsToDrop = existing ? [...(existing.controlPointsToDrop || [])] : [];
+  }
+
+  get canvas() {
+    if (this.type === StrokeType.NotCreated) {
+      return this.intendedCanvas;
+    }
+    if (this.type === StrokeType.BrushStroke) {
+      return this.object ? this.object.canvas : null;
+    }
+    throw new Error('Invalid stroke type');
+  }
+
+  invalidateCopy() {
+    this.copyForSaveThread = null;
+  }
+
+  uncreate() {
+    this.intendedCanvas = this.canvas;
+    this.object = null;
+    this.type = StrokeType.NotCreated;
+  }
+
+  setParent(canvas) {
+    const prevCanvas = this.canvas;
+    if (prevCanvas === canvas) {
+      return;
+    }
+
+    if (this.type === StrokeType.BrushStroke && this.object && typeof this.object.setParent === 'function') {
+      this.object.setParent(canvas);
+    } else {
+      this.intendedCanvas = canvas;
+    }
+  }
+
+  /**
+   * Applies a left transform to all control points. The transform should be an
+   * object with { position: Vector3, rotation: Quaternion, scale: number }.
+   * The brushScale is updated by the transform and the cached copy is invalidated.
+   */
+  leftTransformControlPoints(transform, absoluteScale = false) {
+    let position, rotation, scale;
+    if (transform && transform.translation) {
+      position = transform.translation;
+      rotation = transform.rotation;
+      scale = transform.scale;
+    } else {
+      ({ position = new Vector3(), rotation = new Quaternion(), scale = 1 } = transform || {});
+    }
+    for (const cp of this.controlPoints) {
+      cp.pos.multiplyScalar(scale);
+      cp.pos.applyQuaternion(rotation);
+      cp.pos.add(position);
+      cp.orient.premultiply(rotation);
+    }
+    this.brushScale *= absoluteScale ? Math.abs(scale) : scale;
+    this.invalidateCopy();
+  }
+
+  // TODO: port matrix-based variant
+  leftTransformControlPointsMatrix(matrix) {
+    // TODO: implement using Matrix4 operations
+    throw new Error('leftTransformControlPointsMatrix not implemented');
+  }
+
+  /**
+   * Set the parent canvas while preserving world-space position.
+   * If leftTransform is provided, it will be applied to the control points.
+   * When geometry exists, the stroke is recreated through the provided pointer.
+   */
+  setParentKeepWorldPosition(canvas, pointer, leftTransform = null, absoluteScale = false) {
+    const prevCanvas = this.canvas;
+    if (prevCanvas === canvas) {
+      return;
+    }
+
+    const transform = leftTransform;
+    if (this.type === StrokeType.NotCreated || !transform) {
+      this.setParent(canvas);
+      if (transform) {
+        this.leftTransformControlPoints(transform, absoluteScale);
+      }
+    } else if (this.type === StrokeType.BrushStroke) {
+      this.uncreate();
+      this.intendedCanvas = canvas;
+      this.leftTransformControlPoints(transform, absoluteScale);
+      if (pointer && typeof pointer.recreateLineFromMemory === 'function') {
+        pointer.recreateLineFromMemory(this);
+      }
+    } else {
+      this.setParent(canvas);
+    }
+  }
+
+  /**
+   * Hide or show the stroke's geometry if possible.
+   */
+  hide(hide) {
+    if (this.type === StrokeType.BrushStroke && this.object && typeof this.object.hideBrush === 'function') {
+      this.object.hideBrush(hide);
+    } else if (this.type === StrokeType.NotCreated) {
+      console.error('Unexpected: NotCreated stroke');
+    }
+  }
+
+  // Placeholder for full recreate logic; only handles basic transform/parenting.
+  recreate(pointer, leftTransform = null, canvas = null, absoluteScale = false) {
+    if (leftTransform || this.type === StrokeType.NotCreated) {
+      this.uncreate();
+      if (canvas) {
+        this.setParent(canvas);
+      }
+      if (leftTransform) {
+        this.leftTransformControlPoints(leftTransform, absoluteScale);
+      }
+      if (pointer && typeof pointer.recreateLineFromMemory === 'function') {
+        pointer.recreateLineFromMemory(this);
+      }
+    } else if (canvas) {
+      this.setParent(canvas);
+    } else {
+      throw new Error('Nothing to do');
+    }
+  }
+}
+
+export default Stroke;

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -7,26 +7,28 @@ export class StrokeData {
       this.color = existing.color?.clone ? existing.color.clone() : existing.color;
       this.brushGuid = existing.brushGuid;
       this.brushSize = existing.brushSize;
-      this.brushScale = existing.brushScale;
-      this.seed = existing.seed;
-      this.crossSection = existing.crossSection;
-      this.shapeModifier = existing.shapeModifier;
-      this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
-        cp.pos?.clone ? cp.pos.clone() : cp.pos,
-        cp.orient?.clone ? cp.orient.clone() : cp.orient,
-        cp.pressure,
-        cp.timestampMs
-      ));
-    } else {
+        this.brushScale = existing.brushScale;
+        this.seed = existing.seed;
+        this.crossSection = existing.crossSection;
+        this.shapeModifier = existing.shapeModifier;
+        this.surfaceOffset = existing.surfaceOffset;
+        this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
+          cp.pos?.clone ? cp.pos.clone() : cp.pos,
+          cp.orient?.clone ? cp.orient.clone() : cp.orient,
+          cp.pressure,
+          cp.timestampMs
+        ));
+      } else {
       this.color = new Color();
       this.brushGuid = null;
       this.brushSize = 0;
       this.brushScale = 1;
-      this.seed = 0;
-      this.controlPoints = [];
-      this.crossSection = null;
-      this.shapeModifier = null;
-    }
+        this.seed = 0;
+        this.controlPoints = [];
+        this.crossSection = null;
+        this.shapeModifier = null;
+        this.surfaceOffset = 0;
+      }
 
     const uuidFn = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'
       ? () => globalThis.crypto.randomUUID()

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -1,0 +1,39 @@
+import { Color } from 'three';
+import { ControlPoint } from './ControlPoint.js';
+
+export class StrokeData {
+  constructor(existing = null) {
+    if (existing) {
+      this.color = existing.color?.clone ? existing.color.clone() : existing.color;
+      this.brushGuid = existing.brushGuid;
+      this.brushSize = existing.brushSize;
+      this.brushScale = existing.brushScale;
+      this.seed = existing.seed;
+      this.shapeModifier = existing.shapeModifier;
+      this.silhouetteModifier = existing.silhouetteModifier;
+      this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
+        cp.pos?.clone ? cp.pos.clone() : cp.pos,
+        cp.orient?.clone ? cp.orient.clone() : cp.orient,
+        cp.pressure,
+        cp.timestampMs
+      ));
+    } else {
+      this.color = new Color();
+      this.brushGuid = null;
+      this.brushSize = 0;
+      this.brushScale = 1;
+      this.seed = 0;
+      this.controlPoints = [];
+      this.shapeModifier = null;
+      this.silhouetteModifier = null;
+    }
+
+    const uuidFn = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'
+      ? () => globalThis.crypto.randomUUID()
+      : () => Math.random().toString(36).slice(2);
+
+    this.guid = uuidFn();
+  }
+}
+
+export default StrokeData;

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -9,8 +9,8 @@ export class StrokeData {
       this.brushSize = existing.brushSize;
       this.brushScale = existing.brushScale;
       this.seed = existing.seed;
+      this.crossSection = existing.crossSection;
       this.shapeModifier = existing.shapeModifier;
-      this.silhouetteModifier = existing.silhouetteModifier;
       this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
         cp.pos?.clone ? cp.pos.clone() : cp.pos,
         cp.orient?.clone ? cp.orient.clone() : cp.orient,
@@ -24,8 +24,8 @@ export class StrokeData {
       this.brushScale = 1;
       this.seed = 0;
       this.controlPoints = [];
+      this.crossSection = null;
       this.shapeModifier = null;
-      this.silhouetteModifier = null;
     }
 
     const uuidFn = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -11,8 +11,6 @@ export class StrokeData {
       this.seed = existing.seed;
       this.crossSection = existing.crossSection;
       this.shapeModifier = existing.shapeModifier;
-      this.surfaceOffset = existing.surfaceOffset;
-      this.taperScalar = existing.taperScalar;
       this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
         cp.pos?.clone ? cp.pos.clone() : cp.pos,
         cp.orient?.clone ? cp.orient.clone() : cp.orient,
@@ -28,8 +26,6 @@ export class StrokeData {
       this.controlPoints = [];
       this.crossSection = null;
       this.shapeModifier = null;
-      this.surfaceOffset = 0;
-      this.taperScalar = 1;
     }
 
     const uuidFn = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -11,7 +11,6 @@ export class StrokeData {
         this.seed = existing.seed;
         this.crossSection = existing.crossSection;
         this.shapeModifier = existing.shapeModifier;
-        this.surfaceOffset = existing.surfaceOffset;
         this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
           cp.pos?.clone ? cp.pos.clone() : cp.pos,
           cp.orient?.clone ? cp.orient.clone() : cp.orient,
@@ -27,7 +26,6 @@ export class StrokeData {
         this.controlPoints = [];
         this.crossSection = null;
         this.shapeModifier = null;
-        this.surfaceOffset = 0;
       }
 
     const uuidFn = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'

--- a/js/StrokeData.js
+++ b/js/StrokeData.js
@@ -11,6 +11,8 @@ export class StrokeData {
       this.seed = existing.seed;
       this.crossSection = existing.crossSection;
       this.shapeModifier = existing.shapeModifier;
+      this.surfaceOffset = existing.surfaceOffset;
+      this.taperScalar = existing.taperScalar;
       this.controlPoints = existing.controlPoints.map(cp => new ControlPoint(
         cp.pos?.clone ? cp.pos.clone() : cp.pos,
         cp.orient?.clone ? cp.orient.clone() : cp.orient,
@@ -26,6 +28,8 @@ export class StrokeData {
       this.controlPoints = [];
       this.crossSection = null;
       this.shapeModifier = null;
+      this.surfaceOffset = 0;
+      this.taperScalar = 1;
     }
 
     const uuidFn = globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'

--- a/js/TrTransform.js
+++ b/js/TrTransform.js
@@ -1,0 +1,250 @@
+import { Vector3, Quaternion, Matrix4, Plane } from 'three';
+import QuaternionExtensions from './QuaternionExtensions.js';
+
+/**
+ * Port of Tilt Brush's TrTransform struct.
+ * Represents translation, rotation, and uniform scale.
+ */
+export class TrTransform {
+  constructor(translation = new Vector3(), rotation = new Quaternion(), scale = 1) {
+    this.translation = translation;
+    this.rotation = rotation;
+    this.scale = scale;
+  }
+
+  static identity = TrTransform.TR(new Vector3(), new Quaternion());
+
+  // Methods analogous to Matrix4x4.TRS
+  static T(t) {
+    return new TrTransform(t, new Quaternion(), 1);
+  }
+
+  static RQuaternion(r) {
+    return new TrTransform(new Vector3(), r, 1);
+  }
+
+  static R(angle, axis) {
+    const q = new Quaternion().setFromAxisAngle(axis, angle);
+    return new TrTransform(new Vector3(), q, 1);
+  }
+
+  static S(s) {
+    return new TrTransform(new Vector3(), new Quaternion(), s);
+  }
+
+  static TR(t, r) {
+    return new TrTransform(t, r, 1);
+  }
+
+  static TRS(t, r, s) {
+    return new TrTransform(t, r, s);
+  }
+
+  static fromMatrix4(m) {
+    // TODO: decompose matrix; assumes uniform scale
+    const t = new Vector3();
+    const r = new Quaternion();
+    const s = new Vector3();
+    m.decompose(t, r, s);
+    return new TrTransform(t, r, s.x);
+  }
+
+  static fromTransform(xf) {
+    if (!xf) {
+      throw new Error('fromTransform requires an Object3D');
+    }
+    xf.updateMatrixWorld();
+    const t = new Vector3();
+    const r = new Quaternion();
+    const s = new Vector3();
+    xf.matrixWorld.decompose(t, r, s);
+    return new TrTransform(t, r, s.x);
+  }
+
+  static fromLocalTransform(xf) {
+    if (!xf) {
+      throw new Error('fromLocalTransform requires an Object3D');
+    }
+    const t = xf.position.clone();
+    const r = xf.quaternion.clone();
+    const s = xf.scale.x;
+    return new TrTransform(t, r, s);
+  }
+
+  static invMul(a, b) {
+    const aInvRot = QuaternionExtensions.trueInverse(a.rotation);
+    const translation = b.translation
+      .clone()
+      .sub(a.translation)
+      .divideScalar(a.scale)
+      .applyQuaternion(aInvRot);
+    const rotation = aInvRot.clone().multiply(b.rotation);
+    const scale = b.scale / a.scale;
+    return TrTransform.TRS(translation, rotation, scale);
+  }
+
+  static lerp(a, b, t) {
+    const translation = a.translation.clone().lerp(b.translation, t);
+    const rotation = a.rotation.clone().slerp(b.rotation, t);
+    const scale = Math.exp(Math.log(a.scale) * (1 - t) + Math.log(b.scale) * t);
+    return new TrTransform(translation, rotation, scale);
+  }
+
+  multiplyPoint(p) {
+    return p
+      .clone()
+      .multiplyScalar(this.scale)
+      .applyQuaternion(this.rotation)
+      .add(this.translation);
+  }
+
+  multiplyVector(v) {
+    return v
+      .clone()
+      .multiplyScalar(this.scale)
+      .applyQuaternion(this.rotation);
+  }
+
+  multiplyBivector(v) {
+    return v
+      .clone()
+      .multiplyScalar(this.scale * this.scale)
+      .applyQuaternion(this.rotation);
+  }
+
+  multiplyNormal(v) {
+    return v.clone().applyQuaternion(this.rotation);
+  }
+
+  multiplyPlane(plane) {
+    if (!(plane instanceof Plane)) {
+      throw new Error('multiplyPlane requires a three.js Plane');
+    }
+    // Transform plane assuming uniform scale
+    const normal = plane.normal
+      .clone()
+      .applyQuaternion(this.rotation)
+      .multiplyScalar(1 / this.scale);
+    let constant = plane.constant - normal.dot(this.translation);
+    // Ensure the plane normal remains normalized
+    const len = normal.length();
+    if (len > 0) {
+      normal.multiplyScalar(1 / len);
+      constant *= 1 / len;
+    }
+    return new Plane(normal, constant);
+  }
+
+  mul(b) {
+    return TrTransform.TRS(
+      this.rotation.clone().multiply(b.translation.clone().multiplyScalar(this.scale)).add(this.translation),
+      this.rotation.clone().multiply(b.rotation),
+      this.scale * b.scale
+    );
+  }
+
+  static approximately(lhs, rhs) {
+    const sameTranslation = lhs.translation.equals(rhs.translation);
+    const sameRotation = lhs.rotation.equals(rhs.rotation);
+    const sameScale = Math.abs(lhs.scale - rhs.scale) <= Number.EPSILON;
+    return sameTranslation && sameRotation && sameScale;
+  }
+
+  get inverse() {
+    const rinv = QuaternionExtensions.trueInverse(this.rotation);
+    const invScale = 1 / this.scale;
+    const translation = this.translation
+      .clone()
+      .multiplyScalar(-invScale)
+      .applyQuaternion(rinv);
+    return TrTransform.TRS(translation, rinv, invScale);
+  }
+
+  forward() {
+    return new Vector3(0, 0, 1).applyQuaternion(this.rotation);
+  }
+
+  up() {
+    return new Vector3(0, 1, 0).applyQuaternion(this.rotation);
+  }
+
+  right() {
+    return new Vector3(1, 0, 0).applyQuaternion(this.rotation);
+  }
+
+  isFinite() {
+    return [
+      this.translation.x,
+      this.translation.y,
+      this.translation.z,
+      this.rotation.x,
+      this.rotation.y,
+      this.rotation.z,
+      this.rotation.w,
+      this.scale,
+    ].every(Number.isFinite);
+  }
+
+  toString() {
+    return `T: ${this.translation.x.toExponential()} ${this.translation.y.toExponential()} ${this.translation.z.toExponential()}\n` +
+      `R: ${this.rotation.x.toExponential()} ${this.rotation.y.toExponential()} ${this.rotation.z.toExponential()} ${this.rotation.w.toExponential()}\n` +
+      `S: ${this.scale.toExponential()}`;
+  }
+
+  equals(o) {
+    return (
+      o instanceof TrTransform &&
+      this.translation.equals(o.translation) &&
+      this.rotation.equals(o.rotation) &&
+      this.scale === o.scale
+    );
+  }
+
+  toMatrix4() {
+    const m = new Matrix4();
+    m.compose(
+      this.translation,
+      this.rotation,
+      new Vector3(this.scale, this.scale, this.scale)
+    );
+    return m;
+  }
+
+  toTransform(xf) {
+    if (!xf) {
+      throw new Error('toTransform requires an Object3D');
+    }
+    const m = this.toMatrix4();
+    if (xf.parent) {
+      xf.parent.updateMatrixWorld();
+      const parentInv = new Matrix4().copy(xf.parent.matrixWorld).invert();
+      m.premultiply(parentInv);
+    }
+    m.decompose(xf.position, xf.quaternion, xf.scale);
+    xf.updateMatrix();
+    xf.updateMatrixWorld(true);
+  }
+
+  toLocalTransform(xf) {
+    if (!xf) {
+      throw new Error('toLocalTransform requires an Object3D');
+    }
+    xf.position.copy(this.translation);
+    xf.quaternion.copy(this.rotation);
+    xf.scale.setScalar(this.scale);
+    xf.updateMatrix();
+    xf.updateMatrixWorld(true);
+  }
+
+  transformBy(rhs) {
+    const similar = rhs.rotation.clone().multiply(this.rotation).multiply(QuaternionExtensions.trueInverse(rhs.rotation));
+    const retTrans = similar
+      .clone()
+      .multiply(rhs.translation.clone().multiplyScalar(-this.scale))
+      .add(rhs.rotation.clone().multiply(this.translation.clone().multiplyScalar(rhs.scale)))
+      .add(rhs.translation);
+    return new TrTransform(retTrans, similar, this.scale);
+  }
+}
+
+export default TrTransform;

--- a/js/TransformExtensions.js
+++ b/js/TransformExtensions.js
@@ -1,0 +1,73 @@
+import { Vector3 } from 'three';
+import TrTransform from './TrTransform.js';
+
+/**
+ * Helpers for working with three.js Object3D transforms
+ * using Tilt Brush's TrTransform abstraction.
+ */
+export function getUniformScale(xf) {
+  let uniformScale = xf.scale.x;
+  for (let cur = xf.parent; cur; cur = cur.parent) {
+    uniformScale *= cur.scale.x;
+  }
+  return uniformScale;
+}
+
+export function setUniformScale(xf, scale) {
+  if (xf.parent) {
+    scale /= getUniformScale(xf.parent);
+  }
+  xf.scale.setScalar(scale);
+}
+
+export class LocalAccessor {
+  get(xf) {
+    return TrTransform.fromLocalTransform(xf);
+  }
+
+  set(xf, value) {
+    value.toLocalTransform(xf);
+  }
+}
+
+export class GlobalAccessor {
+  get(xf) {
+    return TrTransform.fromTransform(xf);
+  }
+
+  set(xf, value) {
+    value.toTransform(xf);
+  }
+}
+
+export class RelativeAccessor {
+  constructor(parent) {
+    this.parent = parent;
+    this.asGlobal = new GlobalAccessor();
+    this.asLocal = new LocalAccessor();
+  }
+
+  get(xf) {
+    const parentTf = this.parent
+      ? TrTransform.fromTransform(this.parent)
+      : TrTransform.identity;
+    const childTf = TrTransform.fromTransform(xf);
+    return TrTransform.invMul(parentTf, childTf);
+  }
+
+  set(xf, value) {
+    const parentTf = this.parent
+      ? TrTransform.fromTransform(this.parent)
+      : TrTransform.identity;
+    const world = parentTf.mul(value);
+    world.toTransform(xf);
+  }
+}
+
+export default {
+  getUniformScale,
+  setUniformScale,
+  LocalAccessor,
+  GlobalAccessor,
+  RelativeAccessor,
+};

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -18,8 +18,6 @@ export class TubeBrush extends GeometryBrush {
     this.crossSection = TubeBrush.CrossSection.ROUND;
     // Shape modifier along the length of the stroke
     this.shapeModifier = TubeBrush.ShapeModifier.NONE;
-    // Offset applied along vertex normals when using SURFACE_OFFSET
-    this.surfaceOffset = 0;
   }
 
   initBrush(desc, localPointerXf) {
@@ -145,9 +143,6 @@ export class TubeBrush extends GeometryBrush {
           tmpPos.applyQuaternion(cp.orient).add(cp.pos);
           tmpNormal.applyQuaternion(cp.orient);
         }
-        if (this.shapeModifier === TubeBrush.ShapeModifier.SURFACE_OFFSET) {
-          tmpPos.addScaledVector(tmpNormal, this.surfaceOffset);
-        }
         positions.push(tmpPos.x, tmpPos.y, tmpPos.z);
         normals.push(tmpNormal.x, tmpNormal.y, tmpNormal.z);
         uvs.push(j / radialSegments, i / (cpCount - 1));
@@ -190,7 +185,6 @@ TubeBrush.CrossSection = {
 TubeBrush.ShapeModifier = {
   NONE: 'none',
   TAPER: 'taper',
-  SURFACE_OFFSET: 'surface-offset',
 };
 
 // Height/width ratio used by the square cross-section, mirroring the C# constant

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -18,8 +18,6 @@ export class TubeBrush extends GeometryBrush {
     this.crossSection = TubeBrush.CrossSection.ROUND;
     // Shape modifier along the length of the stroke
     this.shapeModifier = TubeBrush.ShapeModifier.NONE;
-    this.taperScalar = 1.0;
-    this.surfaceOffset = 0;
   }
 
   initBrush(desc, localPointerXf) {
@@ -97,7 +95,7 @@ export class TubeBrush extends GeometryBrush {
       const t = i / (cpCount - 1);
       let radius = baseRadius;
       if (this.shapeModifier === TubeBrush.ShapeModifier.TAPER) {
-        radius *= this.taperScalar * (1 - t);
+        radius *= 1 - t;
       }
       for (let j = 0; j < radialSegments; j++) {
         const angle = (j / radialSegments) * Math.PI * 2;
@@ -113,9 +111,6 @@ export class TubeBrush extends GeometryBrush {
         tmpPos.multiplyScalar(radius);
         tmpNormal.applyQuaternion(cp.orient);
         tmpPos.applyQuaternion(cp.orient).add(cp.pos);
-        if (this.shapeModifier === TubeBrush.ShapeModifier.SURFACE_OFFSET) {
-          tmpPos.addScaledVector(tmpNormal, this.surfaceOffset);
-        }
         positions.push(tmpPos.x, tmpPos.y, tmpPos.z);
         normals.push(tmpNormal.x, tmpNormal.y, tmpNormal.z);
         uvs.push(j / radialSegments, i / (cpCount - 1));
@@ -158,7 +153,6 @@ TubeBrush.CrossSection = {
 TubeBrush.ShapeModifier = {
   NONE: 'none',
   TAPER: 'taper',
-  SURFACE_OFFSET: 'surface_offset',
 };
 
 export default TubeBrush;

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -18,6 +18,8 @@ export class TubeBrush extends GeometryBrush {
     this.crossSection = TubeBrush.CrossSection.ROUND;
     // Shape modifier along the length of the stroke
     this.shapeModifier = TubeBrush.ShapeModifier.NONE;
+    // Offset applied along vertex normals when using SURFACE_OFFSET
+    this.surfaceOffset = 0;
   }
 
   initBrush(desc, localPointerXf) {
@@ -143,6 +145,9 @@ export class TubeBrush extends GeometryBrush {
           tmpPos.applyQuaternion(cp.orient).add(cp.pos);
           tmpNormal.applyQuaternion(cp.orient);
         }
+        if (this.shapeModifier === TubeBrush.ShapeModifier.SURFACE_OFFSET) {
+          tmpPos.addScaledVector(tmpNormal, this.surfaceOffset);
+        }
         positions.push(tmpPos.x, tmpPos.y, tmpPos.z);
         normals.push(tmpNormal.x, tmpNormal.y, tmpNormal.z);
         uvs.push(j / radialSegments, i / (cpCount - 1));
@@ -185,6 +190,7 @@ TubeBrush.CrossSection = {
 TubeBrush.ShapeModifier = {
   NONE: 'none',
   TAPER: 'taper',
+  SURFACE_OFFSET: 'surface-offset',
 };
 
 // Height/width ratio used by the square cross-section, mirroring the C# constant

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -1,0 +1,154 @@
+import {
+  BufferGeometry,
+  Float32BufferAttribute,
+  Mesh,
+  MeshStandardMaterial,
+  Vector3,
+} from 'three';
+import { GeometryBrush } from './GeometryBrush.js';
+
+// Port of Tilt Brush's TubeBrush. This version builds a tube mesh
+// along the collected control points using custom BufferGeometry rather
+// than Three.js's TubeGeometry helper.
+export class TubeBrush extends GeometryBrush {
+  constructor() {
+    super({ canBatch: true, upperBoundVertsPerKnot: 24, doubleSided: false });
+    this.pointsInClosedCircle = 8;
+    this.shapeModifier = TubeBrush.ShapeModifier.NONE;
+    this.silhouetteModifier = TubeBrush.SilhouetteModifier.NONE;
+    this.taperScalar = 1.0;
+  }
+
+  initBrush(desc, localPointerXf) {
+    super.initBrush(desc, localPointerXf);
+    // TODO: mirror TubeBrush-specific initialization from C# version
+  }
+
+  resetBrushForPreview(unusedXf) {
+    super.resetBrushForPreview(unusedXf);
+    // TODO: clear any TubeBrush preview-specific state
+  }
+
+  addControlPoint(cp) {
+    super.addControlPoint(cp);
+    this.controlPointsChanged(this.controlPoints.length - 1);
+  }
+
+  getSpawnInterval(pressure01) {
+    // TODO: compute spawn interval based on pressure and descriptor
+    return this.Descriptor?.m_SolidMinLengthMeters_PS || 0.002;
+  }
+
+  controlPointsChanged(startIndex) {
+    // For now, rebuild the entire mesh whenever control points change.
+    // This mirrors the C# behavior that regenerates geometry incrementally,
+    // but keeps the implementation simple until partial updates are ported.
+    if (this.controlPoints.length < 2) {
+      return;
+    }
+    // Recreate the mesh to reflect new control points.
+    this.finalizeStroke();
+  }
+
+  onChangedFrameKnots(startIndex) {
+    // TODO: frame knots and detect strip breaks
+    return false;
+  }
+
+  onChangedMakeGeometry(startIndex) {
+    // TODO: generate mesh data for affected knots
+  }
+
+  resizeGeometry() {
+    // TODO: resize internal geometry buffers
+  }
+
+  onChangedStretchUVs(startIndex) {
+    // TODO: update UVs when stretch style is active
+  }
+
+  onChangedModifySilhouette(startIndex) {
+    // TODO: apply shape modifiers to the silhouette
+  }
+
+  // Generate a tube mesh along control points without relying on Three.js helpers.
+  createMesh() {
+    const cpCount = this.controlPoints.length;
+    if (cpCount < 2) {
+      return null;
+    }
+
+    const baseRadius = this.BaseSize_LS || 0.01;
+    const radialSegments = this.pointsInClosedCircle;
+
+    const positions = [];
+    const normals = [];
+    const uvs = [];
+    const indices = [];
+
+    const tmpPos = new Vector3();
+    const tmpNormal = new Vector3();
+
+    for (let i = 0; i < cpCount; i++) {
+      const cp = this.controlPoints[i];
+      const t = i / (cpCount - 1);
+      let radius = baseRadius;
+      if (this.silhouetteModifier === TubeBrush.SilhouetteModifier.TAPER) {
+        radius *= this.taperScalar * (1 - t);
+      }
+      for (let j = 0; j < radialSegments; j++) {
+        const angle = (j / radialSegments) * Math.PI * 2;
+        // Base circle coordinates.
+        tmpPos.set(Math.cos(angle), Math.sin(angle), 0);
+        // Apply shape modification to cross-section coordinates.
+        if (this.shapeModifier === TubeBrush.ShapeModifier.SQUARE) {
+          const scale = 1 / Math.max(Math.abs(tmpPos.x), Math.abs(tmpPos.y));
+          tmpPos.x *= scale;
+          tmpPos.y *= scale;
+        }
+        tmpNormal.copy(tmpPos).normalize();
+        tmpPos.multiplyScalar(radius);
+        tmpPos.applyQuaternion(cp.orient).add(cp.pos);
+        tmpNormal.applyQuaternion(cp.orient);
+        positions.push(tmpPos.x, tmpPos.y, tmpPos.z);
+        normals.push(tmpNormal.x, tmpNormal.y, tmpNormal.z);
+        uvs.push(j / radialSegments, i / (cpCount - 1));
+      }
+    }
+
+    for (let i = 0; i < cpCount - 1; i++) {
+      for (let j = 0; j < radialSegments; j++) {
+        const a = i * radialSegments + j;
+        const b = (i + 1) * radialSegments + j;
+        const c = i * radialSegments + (j + 1) % radialSegments;
+        const d = (i + 1) * radialSegments + (j + 1) % radialSegments;
+
+        // Form two triangles for the quad between ring i and i+1 at segment j.
+        indices.push(a, b, d);
+        indices.push(a, d, c);
+      }
+    }
+
+    const geometry = new BufferGeometry();
+    geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
+    geometry.setAttribute('normal', new Float32BufferAttribute(normals, 3));
+    geometry.setAttribute('uv', new Float32BufferAttribute(uvs, 2));
+    geometry.setIndex(indices);
+
+    // Use a lit material so normals can be visually inspected in the demo.
+    const material = new MeshStandardMaterial({ color: this.CurrentColor });
+    return new Mesh(geometry, material);
+  }
+}
+
+TubeBrush.ShapeModifier = {
+  NONE: 'none',
+  SQUARE: 'square',
+};
+
+TubeBrush.SilhouetteModifier = {
+  NONE: 'none',
+  TAPER: 'taper',
+};
+
+export default TubeBrush;

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -14,8 +14,10 @@ export class TubeBrush extends GeometryBrush {
   constructor() {
     super({ canBatch: true, upperBoundVertsPerKnot: 24, doubleSided: false });
     this.pointsInClosedCircle = 8;
+    // Cross-section shape (round by default)
+    this.crossSection = TubeBrush.CrossSection.ROUND;
+    // Shape modifier along the length of the stroke
     this.shapeModifier = TubeBrush.ShapeModifier.NONE;
-    this.silhouetteModifier = TubeBrush.SilhouetteModifier.NONE;
     this.taperScalar = 1.0;
   }
 
@@ -93,15 +95,15 @@ export class TubeBrush extends GeometryBrush {
       const cp = this.controlPoints[i];
       const t = i / (cpCount - 1);
       let radius = baseRadius;
-      if (this.silhouetteModifier === TubeBrush.SilhouetteModifier.TAPER) {
+      if (this.shapeModifier === TubeBrush.ShapeModifier.TAPER) {
         radius *= this.taperScalar * (1 - t);
       }
       for (let j = 0; j < radialSegments; j++) {
         const angle = (j / radialSegments) * Math.PI * 2;
         // Base circle coordinates.
         tmpPos.set(Math.cos(angle), Math.sin(angle), 0);
-        // Apply shape modification to cross-section coordinates.
-        if (this.shapeModifier === TubeBrush.ShapeModifier.SQUARE) {
+        // Apply cross-section modification to ring coordinates.
+        if (this.crossSection === TubeBrush.CrossSection.SQUARE) {
           const scale = 1 / Math.max(Math.abs(tmpPos.x), Math.abs(tmpPos.y));
           tmpPos.x *= scale;
           tmpPos.y *= scale;
@@ -142,12 +144,14 @@ export class TubeBrush extends GeometryBrush {
   }
 }
 
-TubeBrush.ShapeModifier = {
-  NONE: 'none',
+// Cross-section shapes
+TubeBrush.CrossSection = {
+  ROUND: 'round',
   SQUARE: 'square',
 };
 
-TubeBrush.SilhouetteModifier = {
+// Shape modifiers along the stroke length
+TubeBrush.ShapeModifier = {
   NONE: 'none',
   TAPER: 'taper',
 };

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -19,6 +19,7 @@ export class TubeBrush extends GeometryBrush {
     // Shape modifier along the length of the stroke
     this.shapeModifier = TubeBrush.ShapeModifier.NONE;
     this.taperScalar = 1.0;
+    this.surfaceOffset = 0;
   }
 
   initBrush(desc, localPointerXf) {
@@ -110,8 +111,11 @@ export class TubeBrush extends GeometryBrush {
         }
         tmpNormal.copy(tmpPos).normalize();
         tmpPos.multiplyScalar(radius);
-        tmpPos.applyQuaternion(cp.orient).add(cp.pos);
         tmpNormal.applyQuaternion(cp.orient);
+        tmpPos.applyQuaternion(cp.orient).add(cp.pos);
+        if (this.shapeModifier === TubeBrush.ShapeModifier.SURFACE_OFFSET) {
+          tmpPos.addScaledVector(tmpNormal, this.surfaceOffset);
+        }
         positions.push(tmpPos.x, tmpPos.y, tmpPos.z);
         normals.push(tmpNormal.x, tmpNormal.y, tmpNormal.z);
         uvs.push(j / radialSegments, i / (cpCount - 1));
@@ -154,6 +158,7 @@ TubeBrush.CrossSection = {
 TubeBrush.ShapeModifier = {
   NONE: 'none',
   TAPER: 'taper',
+  SURFACE_OFFSET: 'surface_offset',
 };
 
 export default TubeBrush;

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -125,8 +125,8 @@ export class TubeBrush extends GeometryBrush {
 
         // Form two triangles for the quad between ring i and i+1 at segment j.
         // Winding is chosen so face normals align with the generated vertex normals.
-        indices.push(a, d, b);
-        indices.push(a, c, d);
+        indices.push(a, c, b);
+        indices.push(c, d, b);
       }
     }
 

--- a/js/TubeBrush.js
+++ b/js/TubeBrush.js
@@ -124,8 +124,9 @@ export class TubeBrush extends GeometryBrush {
         const d = (i + 1) * radialSegments + (j + 1) % radialSegments;
 
         // Form two triangles for the quad between ring i and i+1 at segment j.
-        indices.push(a, b, d);
-        indices.push(a, d, c);
+        // Winding is chosen so face normals align with the generated vertex normals.
+        indices.push(a, d, b);
+        indices.push(a, c, d);
       }
     }
 

--- a/js/VerifyTubeBrush.js
+++ b/js/VerifyTubeBrush.js
@@ -197,39 +197,6 @@ function verifyTaperShape() {
   console.log('TubeBrush taper shape passed basic checks');
 }
 
-function verifySurfaceOffset() {
-  const cps = buildLineControlPoints();
-  const brush = new TubeBrush();
-  brush.BaseSize_PS = 0.05;
-  brush.shapeModifier = TubeBrush.ShapeModifier.SURFACE_OFFSET;
-  brush.surfaceOffset = 0.02;
-  brush.initBrush({ m_Guid: 'tube-brush' }, TrTransform.identity);
-  for (const cp of cps) {
-    brush.addControlPoint(cp);
-  }
-  const mesh = brush.createMesh();
-  if (!mesh) {
-    throw new Error('TubeBrush returned null mesh for surface-offset modifier');
-  }
-  const radialSegments = brush.pointsInClosedCircle;
-  const positions = mesh.geometry.getAttribute('position');
-  const pos = new Vector3();
-  const center = cps[0].pos;
-  let avgRadius = 0;
-  for (let j = 0; j < radialSegments; j++) {
-    pos.fromBufferAttribute(positions, j);
-    avgRadius += pos.distanceTo(center);
-  }
-  avgRadius /= radialSegments;
-  const expected = (brush.BaseSize_LS || 0.01) + brush.surfaceOffset;
-  console.log(`Surface-offset radius: ${avgRadius}`);
-  if (Math.abs(avgRadius - expected) > 1e-3) {
-    throw new Error('Surface-offset modifier did not adjust radius as expected');
-  }
-  console.log('TubeBrush surface-offset shape passed basic checks');
-}
-
 verifyTubeBrush();
 verifySquareCrossSection();
 verifyTaperShape();
-verifySurfaceOffset();

--- a/js/VerifyTubeBrush.js
+++ b/js/VerifyTubeBrush.js
@@ -1,0 +1,166 @@
+import { Vector3, Quaternion, Matrix4, Color } from 'three';
+import { ControlPoint } from './ControlPoint.js';
+import TubeBrush from './TubeBrush.js';
+import { TrTransform } from './TrTransform.js';
+
+// Build a circular stroke similar to the minimal example
+function buildCircleControlPoints(segments = 16, radius = 1.5) {
+  const cps = [];
+  for (let i = 0; i < segments; i++) {
+    const angle = (i * 2 * Math.PI) / segments;
+    const position = new Vector3(Math.cos(angle) * radius, Math.sin(angle) * radius, 0);
+    const radial = new Vector3(Math.cos(angle), Math.sin(angle), 0);
+    const tangent = new Vector3(-Math.sin(angle), Math.cos(angle), 0);
+    const binormal = new Vector3().crossVectors(tangent, radial).normalize();
+    const matrix = new Matrix4().makeBasis(radial, binormal, tangent);
+    const rotation = new Quaternion().setFromRotationMatrix(matrix);
+    cps.push(new ControlPoint(position, rotation, 1, i));
+  }
+  // close loop
+  const first = cps[0];
+  cps.push(new ControlPoint(first.pos.clone(), first.orient.clone(), first.pressure, segments));
+  return cps;
+}
+
+function buildLineControlPoints(count = 8, spacing = 0.1) {
+  const cps = [];
+  for (let i = 0; i < count; i++) {
+    const position = new Vector3(i * spacing, 0, 0);
+    const radial = new Vector3(0, 1, 0);
+    const tangent = new Vector3(1, 0, 0);
+    const binormal = new Vector3(0, 0, 1);
+    const matrix = new Matrix4().makeBasis(radial, binormal, tangent);
+    const rotation = new Quaternion().setFromRotationMatrix(matrix);
+    cps.push(new ControlPoint(position, rotation, 1, i));
+  }
+  return cps;
+}
+
+function verifyTubeBrush() {
+  const cps = buildCircleControlPoints();
+  const brush = new TubeBrush();
+  brush.BaseSize_PS = 0.05;
+  brush.initBrush({ m_Guid: 'tube-brush' }, TrTransform.identity);
+  for (const cp of cps) {
+    brush.addControlPoint(cp);
+  }
+  const mesh = brush.createMesh();
+  if (!mesh) {
+    throw new Error('TubeBrush returned null mesh');
+  }
+  const radialSegments = brush.pointsInClosedCircle;
+  const radius = brush.BaseSize_LS || 0.01;
+  const positions = mesh.geometry.getAttribute('position');
+  const pos = new Vector3();
+
+  if (positions.count !== cps.length * radialSegments) {
+    throw new Error(`Vertex count ${positions.count} does not match expected ${cps.length * radialSegments}`);
+  }
+
+  let maxError = 0;
+  let minDistFromOrigin = Infinity;
+  for (let i = 0; i < cps.length; i++) {
+    const center = cps[i].pos;
+    for (let j = 0; j < radialSegments; j++) {
+      pos.fromBufferAttribute(positions, i * radialSegments + j);
+      const dist = pos.distanceTo(center);
+      const error = Math.abs(dist - radius);
+      if (error > maxError) maxError = error;
+      const fromOrigin = pos.length();
+      if (fromOrigin < minDistFromOrigin) minDistFromOrigin = fromOrigin;
+    }
+  }
+
+  console.log(`Max radial error: ${maxError}`);
+  console.log(`Closest vertex distance from origin: ${minDistFromOrigin}`);
+
+  if (maxError > 1e-3) {
+    throw new Error('Radial variance exceeds tolerance');
+  }
+  if (minDistFromOrigin < radius * 0.5) {
+    throw new Error('Detected vertex too close to origin');
+  }
+  console.log('TubeBrush geometry passed basic checks');
+}
+
+function verifySquareModifier() {
+  const cps = buildCircleControlPoints();
+  const brush = new TubeBrush();
+  brush.BaseSize_PS = 0.05;
+  brush.shapeModifier = TubeBrush.ShapeModifier.SQUARE;
+  brush.initBrush({ m_Guid: 'tube-brush' }, TrTransform.identity);
+  for (const cp of cps) {
+    brush.addControlPoint(cp);
+  }
+  const mesh = brush.createMesh();
+  if (!mesh) {
+    throw new Error('TubeBrush returned null mesh for square shape');
+  }
+  const radialSegments = brush.pointsInClosedCircle;
+  const radius = brush.BaseSize_LS || 0.01;
+  const positions = mesh.geometry.getAttribute('position');
+  const pos = new Vector3();
+
+  const local = new Vector3();
+  const inv = new Quaternion();
+  let maxError = 0;
+  for (let i = 0; i < cps.length; i++) {
+    const center = cps[i].pos;
+    inv.copy(cps[i].orient).invert();
+    for (let j = 0; j < radialSegments; j++) {
+      pos.fromBufferAttribute(positions, i * radialSegments + j);
+      local.copy(pos).sub(center).applyQuaternion(inv);
+      const maxComponent = Math.max(Math.abs(local.x), Math.abs(local.y));
+      const error = Math.abs(maxComponent - radius);
+      if (error > maxError) maxError = error;
+    }
+  }
+
+  console.log(`Max square error: ${maxError}`);
+  if (maxError > 1e-3) {
+    throw new Error('Square shape variance exceeds tolerance');
+  }
+  console.log('TubeBrush square modifier passed basic checks');
+}
+
+function verifyTaperModifier() {
+  const cps = buildLineControlPoints();
+  const brush = new TubeBrush();
+  brush.BaseSize_PS = 0.05;
+  brush.silhouetteModifier = TubeBrush.SilhouetteModifier.TAPER;
+  brush.initBrush({ m_Guid: 'tube-brush' }, TrTransform.identity);
+  for (const cp of cps) {
+    brush.addControlPoint(cp);
+  }
+  const mesh = brush.createMesh();
+  if (!mesh) {
+    throw new Error('TubeBrush returned null mesh for taper modifier');
+  }
+  const radialSegments = brush.pointsInClosedCircle;
+  const positions = mesh.geometry.getAttribute('position');
+  const pos = new Vector3();
+
+  const firstCenter = cps[0].pos;
+  const lastCenter = cps[cps.length - 1].pos;
+  let firstRadius = 0;
+  let lastRadius = 0;
+  for (let j = 0; j < radialSegments; j++) {
+    pos.fromBufferAttribute(positions, j);
+    firstRadius += pos.distanceTo(firstCenter);
+    pos.fromBufferAttribute(positions, (cps.length - 1) * radialSegments + j);
+    lastRadius += pos.distanceTo(lastCenter);
+  }
+  firstRadius /= radialSegments;
+  lastRadius /= radialSegments;
+
+  console.log(`First ring radius: ${firstRadius}`);
+  console.log(`Last ring radius: ${lastRadius}`);
+  if (lastRadius > firstRadius * 0.25) {
+    throw new Error('Taper modifier did not reduce radius sufficiently');
+  }
+  console.log('TubeBrush taper modifier passed basic checks');
+}
+
+verifyTubeBrush();
+verifySquareModifier();
+verifyTaperModifier();

--- a/js/VerifyTubeBrush.js
+++ b/js/VerifyTubeBrush.js
@@ -89,6 +89,26 @@ function verifyTubeBrush() {
   if (minNormalDot < 0.5) {
     throw new Error('Normals appear to be flipped or inaccurate');
   }
+
+  // Ensure triangle winding matches vertex normals by comparing face normals
+  // against the normal of the first vertex in each triangle.
+  const indexAttr = mesh.geometry.getIndex();
+  const indicesArr = indexAttr.array;
+  const v0 = new Vector3();
+  const v1 = new Vector3();
+  const v2 = new Vector3();
+  const n0 = new Vector3();
+  const tri = new Vector3();
+  for (let i = 0; i < indicesArr.length; i += 3) {
+    v0.fromBufferAttribute(positions, indicesArr[i]);
+    v1.fromBufferAttribute(positions, indicesArr[i + 1]);
+    v2.fromBufferAttribute(positions, indicesArr[i + 2]);
+    tri.subVectors(v1, v0).cross(v2.clone().sub(v0)).normalize();
+    n0.fromBufferAttribute(normalsAttr, indicesArr[i]);
+    if (tri.dot(n0) < 0.5) {
+      throw new Error('Triangle winding is inconsistent with vertex normals');
+    }
+  }
   console.log('TubeBrush geometry passed basic checks');
 }
 

--- a/js/VerifyTubeBrush.js
+++ b/js/VerifyTubeBrush.js
@@ -127,6 +127,8 @@ function verifySquareCrossSection() {
   }
   const radialSegments = brush.pointsInClosedCircle;
   const radius = brush.BaseSize_LS || 0.01;
+  const halfW = radius;
+  const halfH = radius * TubeBrush.kCrossSectionAspect;
   const positions = mesh.geometry.getAttribute('position');
   const pos = new Vector3();
 
@@ -139,9 +141,14 @@ function verifySquareCrossSection() {
     for (let j = 0; j < radialSegments; j++) {
       pos.fromBufferAttribute(positions, i * radialSegments + j);
       local.copy(pos).sub(center).applyQuaternion(inv);
-      const maxComponent = Math.max(Math.abs(local.x), Math.abs(local.y));
-      const error = Math.abs(maxComponent - radius);
-      if (error > maxError) maxError = error;
+      const xAbs = Math.abs(local.x);
+      const yAbs = Math.abs(local.y);
+      // ensure vertex lies on rectangle boundary within tolerance
+      const edgeError = Math.min(Math.abs(xAbs - halfW), Math.abs(yAbs - halfH));
+      if (edgeError > maxError) maxError = edgeError;
+      if (xAbs > halfW + 1e-3 || yAbs > halfH + 1e-3) {
+        throw new Error('Vertex outside expected square bounds');
+      }
     }
   }
 

--- a/js/VerifyTubeBrush.js
+++ b/js/VerifyTubeBrush.js
@@ -1,4 +1,4 @@
-import { Vector3, Quaternion, Matrix4, Color } from 'three';
+import { Vector3, Quaternion, Matrix4 } from 'three';
 import { ControlPoint } from './ControlPoint.js';
 import TubeBrush from './TubeBrush.js';
 import { TrTransform } from './TrTransform.js';
@@ -190,39 +190,6 @@ function verifyTaperShape() {
   console.log('TubeBrush taper shape passed basic checks');
 }
 
-function verifySurfaceOffset() {
-  const cps = buildLineControlPoints();
-  const brush = new TubeBrush();
-  brush.BaseSize_PS = 0.05;
-  brush.shapeModifier = TubeBrush.ShapeModifier.SURFACE_OFFSET;
-  brush.surfaceOffset = 0.02;
-  brush.initBrush({ m_Guid: 'tube-brush' }, TrTransform.identity);
-  for (const cp of cps) {
-    brush.addControlPoint(cp);
-  }
-  const mesh = brush.createMesh();
-  if (!mesh) {
-    throw new Error('TubeBrush returned null mesh for surface offset modifier');
-  }
-  const radialSegments = brush.pointsInClosedCircle;
-  const positions = mesh.geometry.getAttribute('position');
-  const pos = new Vector3();
-  const center = cps[0].pos;
-  let avgRadius = 0;
-  for (let j = 0; j < radialSegments; j++) {
-    pos.fromBufferAttribute(positions, j);
-    avgRadius += pos.distanceTo(center);
-  }
-  avgRadius /= radialSegments;
-  console.log(`Surface offset ring radius: ${avgRadius}`);
-  const expected = brush.BaseSize_LS + brush.surfaceOffset;
-  if (Math.abs(avgRadius - expected) > 1e-3) {
-    throw new Error('Surface offset did not adjust radius as expected');
-  }
-  console.log('TubeBrush surface offset passed basic checks');
-}
-
 verifyTubeBrush();
 verifySquareCrossSection();
 verifyTaperShape();
-verifySurfaceOffset();

--- a/js/VerifyTubeBrush.js
+++ b/js/VerifyTubeBrush.js
@@ -197,6 +197,39 @@ function verifyTaperShape() {
   console.log('TubeBrush taper shape passed basic checks');
 }
 
+function verifySurfaceOffset() {
+  const cps = buildLineControlPoints();
+  const brush = new TubeBrush();
+  brush.BaseSize_PS = 0.05;
+  brush.shapeModifier = TubeBrush.ShapeModifier.SURFACE_OFFSET;
+  brush.surfaceOffset = 0.02;
+  brush.initBrush({ m_Guid: 'tube-brush' }, TrTransform.identity);
+  for (const cp of cps) {
+    brush.addControlPoint(cp);
+  }
+  const mesh = brush.createMesh();
+  if (!mesh) {
+    throw new Error('TubeBrush returned null mesh for surface-offset modifier');
+  }
+  const radialSegments = brush.pointsInClosedCircle;
+  const positions = mesh.geometry.getAttribute('position');
+  const pos = new Vector3();
+  const center = cps[0].pos;
+  let avgRadius = 0;
+  for (let j = 0; j < radialSegments; j++) {
+    pos.fromBufferAttribute(positions, j);
+    avgRadius += pos.distanceTo(center);
+  }
+  avgRadius /= radialSegments;
+  const expected = (brush.BaseSize_LS || 0.01) + brush.surfaceOffset;
+  console.log(`Surface-offset radius: ${avgRadius}`);
+  if (Math.abs(avgRadius - expected) > 1e-3) {
+    throw new Error('Surface-offset modifier did not adjust radius as expected');
+  }
+  console.log('TubeBrush surface-offset shape passed basic checks');
+}
+
 verifyTubeBrush();
 verifySquareCrossSection();
 verifyTaperShape();
+verifySurfaceOffset();

--- a/js/VerifyTubeBrush.js
+++ b/js/VerifyTubeBrush.js
@@ -112,11 +112,11 @@ function verifyTubeBrush() {
   console.log('TubeBrush geometry passed basic checks');
 }
 
-function verifySquareModifier() {
+function verifySquareCrossSection() {
   const cps = buildCircleControlPoints();
   const brush = new TubeBrush();
   brush.BaseSize_PS = 0.05;
-  brush.shapeModifier = TubeBrush.ShapeModifier.SQUARE;
+  brush.crossSection = TubeBrush.CrossSection.SQUARE;
   brush.initBrush({ m_Guid: 'tube-brush' }, TrTransform.identity);
   for (const cp of cps) {
     brush.addControlPoint(cp);
@@ -149,14 +149,14 @@ function verifySquareModifier() {
   if (maxError > 1e-3) {
     throw new Error('Square shape variance exceeds tolerance');
   }
-  console.log('TubeBrush square modifier passed basic checks');
+  console.log('TubeBrush square cross-section passed basic checks');
 }
 
-function verifyTaperModifier() {
+function verifyTaperShape() {
   const cps = buildLineControlPoints();
   const brush = new TubeBrush();
   brush.BaseSize_PS = 0.05;
-  brush.silhouetteModifier = TubeBrush.SilhouetteModifier.TAPER;
+  brush.shapeModifier = TubeBrush.ShapeModifier.TAPER;
   brush.initBrush({ m_Guid: 'tube-brush' }, TrTransform.identity);
   for (const cp of cps) {
     brush.addControlPoint(cp);
@@ -187,9 +187,9 @@ function verifyTaperModifier() {
   if (lastRadius > firstRadius * 0.25) {
     throw new Error('Taper modifier did not reduce radius sufficiently');
   }
-  console.log('TubeBrush taper modifier passed basic checks');
+  console.log('TubeBrush taper shape passed basic checks');
 }
 
 verifyTubeBrush();
-verifySquareModifier();
-verifyTaperModifier();
+verifySquareCrossSection();
+verifyTaperShape();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "open-brush-stroke-gen-js",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "open-brush-stroke-gen-js",
+      "version": "1.0.0",
+      "dependencies": {
+        "three": "^0.164.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.164.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.164.1.tgz",
+      "integrity": "sha512-iC/hUBbl1vzFny7f5GtqzVXYjMJKaTPxiCxXfrvVdBi1Sf+jhd1CAkitiFwC7mIBFCo3MrDLJG97yisoaWig0w==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "open-brush-stroke-gen-js",
+  "version": "1.0.0",
+  "description": "JavaScript utilities ported from Unity C# for three.js",
+  "type": "module",
+  "dependencies": {
+    "three": "^0.164.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Add lit demo scenes with circular and open strokes to showcase TubeBrush shape modifiers
- Support open-stroke generation and catalog initialization helpers in the example
- Shade TubeBrush meshes with standard materials for normal-based lighting

## Testing
- `npm install`
- `node -e "import('./js/Pointer.js')"`
- `node -e "import('./js/MinimalExample.js')"`
- `node js/VerifyTubeBrush.js`


------
https://chatgpt.com/codex/tasks/task_e_689392e088408331b9352e375c9cf5c4