### PR TITLE
refactor: introduce non-monobehaviour core classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS
+
+## Coding Guidelines
+- Move functionality out of Unity `MonoBehaviour` classes into plain C# classes.
+- Keep `MonoBehaviour` scripts as small wrappers that forward calls to the standalone classes.
+- Place new C# source files in `Assets/Scripts` and ensure namespaces remain `TiltBrush`.
+- When adding files or modifying code, run `dotnet build` from the repository root.
+
+## Unity Independence Plan
+1. **Consolidate core logic** – ensure all features live in non-`MonoBehaviour` classes with stubs limited to serialization and event forwarding.
+2. **Abstract Unity APIs** – wrap calls to `UnityEngine` systems (e.g. time, input, transforms, file I/O) behind interfaces so they can be swapped with non‑Unity implementations.
+3. **Replace Unity assets** – migrate ScriptableObjects, prefabs, and other asset data to JSON or plain C# representations.
+4. **Introduce core build target** – add `.csproj` files and build scripts so the standalone core can compile and run with `dotnet` without Unity.
+5. **Provide test harness** – create unit or integration tests that exercise the core library outside the Unity runtime.
+
+
+## Progress
+- Moved brush undo cloning logic into standalone `BaseBrush` helper, further shrinking `BaseBrushScript`.
+- TODO: migrate remaining brush behaviors into non-`MonoBehaviour` classes.

--- a/Assets/Scripts/App.cs
+++ b/Assets/Scripts/App.cs
@@ -16,29 +16,12 @@ using UnityEngine;
 
 namespace TiltBrush
 {
-    public class App : MonoBehaviour
+    public static class App
     {
-        public const float METERS_TO_UNITS = 10f;
-        public const float UNITS_TO_METERS = .1f;
+        public const float METERS_TO_UNITS = AppCore.METERS_TO_UNITS;
+        public const float UNITS_TO_METERS = AppCore.UNITS_TO_METERS;
 
-        /// Time origin of sketch in seconds for case when drawing is not sync'd to media.
-        private static double m_sketchTimeBase = 0;
         public static double CurrentSketchTime =>
-            // Unity's Time.time has useful precision probably <= 1ms, and unknown
-            // drift/accuracy. It is a single (but is a double, internally), so its
-            // raw precision drops to ~2ms after ~4 hours and so on.
-            // Time.timeSinceLevelLoad is also an option.
-            //
-            // C#'s DateTime API has low-ish precision (10+ ms depending on OS)
-            // but likely the highest accuracy with respect to wallclock, since
-            // it's reading from an RTC.
-            //
-            // High-precision timers are the opposite: high precision, but are
-            // subject to drift.
-            //
-            // For realtime sync, Time.time is probably the best thing to use.
-            // For postproduction sync, probably C# DateTime.
-            // If you change this, also modify SketchTimeToLevelLoadTime
-            Time.timeSinceLevelLoad - m_sketchTimeBase;
+            AppCore.GetCurrentSketchTime(Time.timeSinceLevelLoad);
     }
 }

--- a/Assets/Scripts/AppCore.cs
+++ b/Assets/Scripts/AppCore.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace TiltBrush
+{
+    public static class AppCore
+    {
+        public const float METERS_TO_UNITS = 10f;
+        public const float UNITS_TO_METERS = 0.1f;
+
+        private static double m_sketchTimeBase = 0;
+        public static double GetCurrentSketchTime(double timeSinceLevelLoad)
+        {
+            return timeSinceLevelLoad - m_sketchTimeBase;
+        }
+    }
+}

--- a/Assets/Scripts/AppCore.cs.meta
+++ b/Assets/Scripts/AppCore.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee6349b6a44b4b98a5d4712d84cbf9b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Brushes/BaseBrush.cs
+++ b/Assets/Scripts/Brushes/BaseBrush.cs
@@ -1,0 +1,28 @@
+using Object = UnityEngine.Object;
+using UnityEngine;
+
+namespace TiltBrush
+{
+    /// <summary>
+    /// Non-MonoBehaviour helpers for brush functionality.
+    /// </summary>
+    public static class BaseBrush
+    {
+        /// <summary>
+        /// Clone the given brush GameObject for use in undo operations.
+        /// The clone is parented like the source and activated.
+        /// A callback allows callers to perform additional initialization.
+        /// </summary>
+        public static GameObject CloneAsUndoObject(GameObject source, System.Action<GameObject> initUndoClone)
+        {
+            GameObject clone = Object.Instantiate(source);
+            clone.name = "Undo " + clone.name;
+            clone.transform.parent = source.transform.parent;
+            Coords.AsLocal[clone.transform] = Coords.AsLocal[source.transform];
+            clone.SetActive(true);
+            Object.Destroy(clone.GetComponent<BaseBrushScript>());
+            initUndoClone?.Invoke(clone);
+            return clone;
+        }
+    }
+}

--- a/Assets/Scripts/Brushes/BaseBrush.cs.meta
+++ b/Assets/Scripts/Brushes/BaseBrush.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6392d62c-e01c-431e-ad94-7701f81ba65a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Brushes/BaseBrushScript.cs
+++ b/Assets/Scripts/Brushes/BaseBrushScript.cs
@@ -160,14 +160,7 @@ namespace TiltBrush
         /// Returns an object that implements the Undo animation
         public GameObject CloneAsUndoObject()
         {
-            GameObject clone = Instantiate(gameObject);
-            clone.name = "Undo " + clone.name;
-            clone.transform.parent = gameObject.transform.parent;
-            Coords.AsLocal[clone.transform] = Coords.AsLocal[gameObject.transform];
-            clone.SetActive(true);
-            Destroy(clone.GetComponent<BaseBrushScript>());
-            InitUndoClone(clone);
-            return clone;
+            return BaseBrush.CloneAsUndoObject(gameObject, InitUndoClone);
         }
 
         /// Returns true if permanent geometry was generated.

--- a/Assets/Scripts/Canvas.cs
+++ b/Assets/Scripts/Canvas.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace TiltBrush
+{
+    public class Canvas
+    {
+        private readonly Transform m_Transform;
+
+        public Canvas(Transform transform)
+        {
+            m_Transform = transform;
+        }
+
+        public TrTransform Pose => Coords.AsGlobal[m_Transform];
+    }
+}

--- a/Assets/Scripts/Canvas.cs.meta
+++ b/Assets/Scripts/Canvas.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c474728e39a34b06ac55d0f7d4c01d43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/CanvasScript.cs
+++ b/Assets/Scripts/CanvasScript.cs
@@ -19,7 +19,12 @@ namespace TiltBrush
 
     public class CanvasScript : MonoBehaviour
     {
-        public TrTransform Pose => Coords.AsGlobal[transform];
+        public Canvas Core { get; private set; }
+
+        void Awake()
+        {
+            Core = new Canvas(transform);
+        }
     }
 
 } // namespace TiltBrush

--- a/Assets/Scripts/Pointer.cs
+++ b/Assets/Scripts/Pointer.cs
@@ -1,0 +1,306 @@
+﻿// Copyright 2020 The Tilt Brush Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace TiltBrush
+{
+
+    public class Pointer
+    {
+        // ---- public types
+
+        public bool DrawingEnabled;
+        private bool m_WasDrawingEnabled;
+        private CanvasScript m_Canvas;
+        public CanvasScript Canvas
+        {
+            get => m_Canvas;
+            set => m_Canvas = value;
+        }
+
+        // ---- Private inspector data
+
+        // ---- Private member data
+
+        public Color m_CurrentColor;
+        public BrushDescriptor m_CurrentBrush;
+        public float m_CurrentBrushSize; // In pointer aka room space
+        private Vector2 m_BrushSizeRange;
+        public float m_CurrentPressure; // TODO: remove and query line instead?
+        private BaseBrushScript m_CurrentLine;
+        private List<ControlPoint> m_ControlPoints;
+        private bool m_LastControlPointIsKeeper;
+
+        // ---- Public properties, accessors, events
+
+        float _FromRadius(float x)
+        {
+            return Mathf.Sqrt(x);
+        }
+        float _ToRadius(float x)
+        {
+            return x * x;
+        }
+
+        /// The brush size, using "normalized" values in the range [0,1].
+        /// On get, values are raw and may be outside [0,1].
+        /// On set, values outside of the range [0,1] are clamped.
+        public float BrushSize01
+        {
+            get
+            {
+                float min = _FromRadius(m_BrushSizeRange.x);
+                float max = _FromRadius(m_BrushSizeRange.y);
+                return Mathf.InverseLerp(min, max, _FromRadius(BrushSizeAbsolute));
+            }
+            set
+            {
+                float min = _FromRadius(m_BrushSizeRange.x);
+                float max = _FromRadius(m_BrushSizeRange.y);
+                BrushSizeAbsolute = _ToRadius(Mathf.Lerp(min, max, Mathf.Clamp01(value)));
+            }
+        }
+
+        /// The brush size, in absolute room space units.
+        /// On get, values are raw and may be outside the brush's desired range.
+        /// On set, values outside the brush's nominal range are clamped.
+        public float BrushSizeAbsolute
+        {
+            get => m_CurrentBrushSize;
+            set => _SetBrushSizeAbsolute(Mathf.Clamp(value, m_BrushSizeRange.x, m_BrushSizeRange.y));
+        }
+
+        // ---- Unity events
+
+        public void Initialize()
+        {
+            m_ControlPoints = new List<ControlPoint>();
+            m_CurrentBrushSize = 1.0f;
+            m_BrushSizeRange.x = 1.0f;
+            m_BrushSizeRange.y = 2.0f;
+            m_CurrentPressure = 1.0f;
+        }
+
+        public void Tick(Transform pointerTransform)
+        {
+            if (DrawingEnabled && !m_WasDrawingEnabled)
+            {
+                // Drawing just got enabled, so we need to create a new line.
+                // This is a no-op if the current line is already set.
+                CreateNewLine(m_Canvas, TrTransform.FromLocalTransform(pointerTransform));
+            }
+            else if (DrawingEnabled && m_WasDrawingEnabled)
+            {
+                UpdateLineFromObject(pointerTransform);
+            }
+            else if (!DrawingEnabled && m_WasDrawingEnabled)
+            {
+                DetachLine(false);
+            }
+            m_WasDrawingEnabled = DrawingEnabled;
+        }
+
+        /// Returns xf_RS, relative to the passed line transform.
+        /// Applies m_LineDepth and ignores xf_RS.scale
+        /// TODO: see above.
+        TrTransform GetTransformForLine(Transform line, TrTransform xf_RS)
+        {
+            var xfRoomFromLine = Coords.AsRoom[line];
+            xf_RS.translation += xf_RS.forward;
+            xf_RS.scale = 1;
+            return TrTransform.InvMul(xfRoomFromLine, xf_RS);
+        }
+
+        /// Non-playback case:
+        /// - Update the stroke based on the object's position.
+        /// - Save off control points
+        /// - Play audio.
+        public void UpdateLineFromObject(Transform pointerTransform)
+        {
+            if (m_CurrentLine == null) return;
+            var xf_LS = GetTransformForLine(m_CurrentLine.transform, Coords.AsRoom[pointerTransform]);
+
+            bool bQuadCreated = m_CurrentLine.UpdatePosition_LS(xf_LS, m_CurrentPressure);
+
+            // TODO: let brush take care of storing control points, not us
+            SetControlPoint(xf_LS, isKeeper: bQuadCreated);
+            UpdateLineVisuals();
+        }
+
+        /// Playback case:
+        /// - Update stroke based on the passed transform (in local coordinates)
+        /// - Do _not_ apply any normal adjustment; it's baked into the control point
+        /// - Do not update the mesh
+        /// TODO: replace with a bulk-ControlPoint API
+        public void UpdateLineFromControlPoint(ControlPoint cp)
+        {
+            float scale = m_CurrentLine.StrokeScale;
+            m_CurrentLine.UpdatePosition_LS(
+                TrTransform.TRS(cp.m_Pos, cp.m_Orient, scale), cp.m_Pressure);
+        }
+
+        /// Bulk control point addition
+        public void UpdateLineFromStroke(Stroke stroke)
+        {
+            float scale = m_CurrentLine.StrokeScale;
+            foreach (var cp in stroke.m_ControlPoints.Where((x, i) => !stroke.m_ControlPointsToDrop[i]))
+            {
+                m_CurrentLine.UpdatePosition_LS(TrTransform.TRS(cp.m_Pos, cp.m_Orient, scale), cp.m_Pressure);
+            }
+        }
+
+        public void UpdateLineVisuals()
+        {
+            m_CurrentLine.ApplyChangesToVisuals();
+        }
+
+        void _SetBrushSizeAbsolute(float value)
+        {
+            m_CurrentBrushSize = value;
+        }
+
+        /// Pass a Canvas parent, and a transform in that canvas's space.
+        /// If overrideDesc passed, use that for the visuals -- m_CurrentBrush does not change.
+        public void CreateNewLine(CanvasScript canvas, TrTransform xf_CS, BrushDescriptor overrideDesc = null)
+        {
+            // If straightedge is enabled, we may have a minimum size requirement.
+            // Initialize parametric stroke creator for our type of straightedge.
+            // Maybe change the brush to a proxy brush.
+            BrushDescriptor desc = overrideDesc != null ? overrideDesc : m_CurrentBrush;
+
+            m_CurrentLine = BaseBrushScript.Create(
+                canvas.transform, xf_CS,
+                desc, m_CurrentColor, m_CurrentBrushSize);
+        }
+
+        /// Like BeginLineFromMemory + EndLineFromMemory
+        /// To help catch bugs in higher-level stroke code, it is considered
+        /// an error unless the stroke is in state NotCreated.
+        public void RecreateLineFromMemory(Stroke stroke, Transform pointerTransform)
+        {
+            if (stroke.m_Type != Stroke.Type.NotCreated)
+            {
+                throw new InvalidOperationException();
+            }
+            if (BeginLineFromMemory(stroke, stroke.Canvas, pointerTransform) == null)
+            {
+                // Unclear why it would have failed, but okay.
+                // I guess we keep the old version?
+                Debug.LogError("Unexpected error recreating line");
+                return;
+            }
+
+            UpdateLineFromStroke(stroke);
+
+            // It's kind of warty that this needs to happen; brushes should probably track
+            // the mesh-dirty state and flush it in Finalize().
+            // TODO: Check if this is still necessary now that QuadStripBrushStretchUV
+            // flushes pending geometry changes in Finalize*Brush()
+            m_CurrentLine.ApplyChangesToVisuals();
+
+            // Copy in new contents
+            {
+                m_CurrentLine.FinalizeSolitaryBrush();
+
+                stroke.m_Type = Stroke.Type.BrushStroke;
+                stroke.m_IntendedCanvas = null;
+                stroke.m_Object = m_CurrentLine.gameObject;
+                stroke.m_Object.GetComponent<BaseBrushScript>().Stroke = stroke;
+            }
+
+            m_CurrentLine = null;
+        }
+
+        public GameObject BeginLineFromMemory(Stroke stroke, CanvasScript canvas, Transform pointerTransform)
+        {
+            BrushDescriptor rBrush = BrushCatalog.GetBrush(stroke.m_BrushGuid);
+            if (rBrush == null)
+            {
+                // Ignore stroke
+                return null;
+            }
+
+            var cp0 = stroke.m_ControlPoints[0];
+            var xf_CS = TrTransform.TRS(cp0.m_Pos, cp0.m_Orient, stroke.m_BrushScale);
+            var xf_RS = canvas.Core.Pose * xf_CS;
+
+            // This transform used to be incorrect, but we didn't notice.
+            // That implies this isn't necessary?
+            pointerTransform.position = xf_RS.translation;
+            pointerTransform.rotation = xf_RS.rotation;
+
+            m_CurrentBrush = rBrush;
+            m_CurrentBrushSize = stroke.m_BrushSize;
+            m_CurrentColor = stroke.m_Color;
+            CreateNewLine(canvas, xf_CS);
+            m_CurrentLine.SetIsLoading();
+            m_CurrentLine.RandomSeed = stroke.m_Seed;
+
+            return m_CurrentLine.gameObject;
+        }
+
+        /// Record the tranform as a control point.
+        /// If the most-recent point is a keeper, append a new control point.
+        /// Otherwise, the most-recent point is a keeper, and will be overwritten.
+        ///
+        /// The parameter "keep" specifies whether the newly-written point is a keeper.
+        ///
+        /// The current pointer is /not/ queried to get the transform of the new
+        /// control point. Instead, caller is responsible for passing in the same
+        /// xf that was passed to line.UpdatePosition_LS()
+        public void SetControlPoint(TrTransform lastSpawnXf_LS, bool isKeeper)
+        {
+            ControlPoint rControlPoint;
+            rControlPoint.m_Pos = lastSpawnXf_LS.translation;
+            rControlPoint.m_Orient = lastSpawnXf_LS.rotation;
+            rControlPoint.m_Pressure = m_CurrentPressure;
+            rControlPoint.m_TimestampMs = (uint)(App.CurrentSketchTime * 1000);
+
+            if (m_ControlPoints.Count == 0 || m_LastControlPointIsKeeper)
+            {
+                m_ControlPoints.Add(rControlPoint);
+            }
+            else
+            {
+                m_ControlPoints[m_ControlPoints.Count - 1] = rControlPoint;
+            }
+
+            m_LastControlPointIsKeeper = isKeeper;
+        }
+
+
+        // During playback, rMemoryObjectForPlayback is non-null, and strokeFlags should not be passed.
+        // otherwise, rMemoryObjectForPlayback is null, and strokeFlags should be valid.
+        // When non-null, rMemoryObjectForPlayback corresponds to the current line.
+        public void DetachLine(bool bDiscard)
+        {
+            if (bDiscard)
+            {
+                m_CurrentLine.DestroyMesh();
+                Object.Destroy(m_CurrentLine.gameObject);
+            }
+            else
+            {
+                //copy master brush over to current line
+                m_CurrentLine.FinalizeSolitaryBrush();
+            }
+            m_CurrentLine = null;
+        }
+    }
+} // namespace TiltBrush

--- a/Assets/Scripts/Pointer.cs.meta
+++ b/Assets/Scripts/Pointer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00821e6b6cf94085add3f44c5407043c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PointerScript.cs
+++ b/Assets/Scripts/PointerScript.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 The Tilt Brush Authors
+// Copyright 2020 The Tilt Brush Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,294 +12,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 namespace TiltBrush
 {
-
     public class PointerScript : MonoBehaviour
     {
-        // ---- public types
-
+        // Serialized fields mirrored to the standalone Pointer implementation.
         public bool DrawingEnabled;
-        private bool m_WasDrawingEnabled;
-        private CanvasScript m_Canvas;
-        public CanvasScript Canvas
-        {
-            get => m_Canvas;
-            set => m_Canvas = value;
-        }
-
-        // ---- Private inspector data
-
-        // ---- Private member data
-
         public Color m_CurrentColor;
         public BrushDescriptor m_CurrentBrush;
-        public float m_CurrentBrushSize; // In pointer aka room space
-        private Vector2 m_BrushSizeRange;
-        public float m_CurrentPressure; // TODO: remove and query line instead?
-        private BaseBrushScript m_CurrentLine;
-        private List<ControlPoint> m_ControlPoints;
-        private bool m_LastControlPointIsKeeper;
+        public float m_CurrentBrushSize;
+        public float m_CurrentPressure;
+        public CanvasScript Canvas;
 
-        // ---- Public properties, accessors, events
-
-        float _FromRadius(float x)
-        {
-            return Mathf.Sqrt(x);
-        }
-        float _ToRadius(float x)
-        {
-            return x * x;
-        }
-
-        /// The brush size, using "normalized" values in the range [0,1].
-        /// On get, values are raw and may be outside [0,1].
-        /// On set, values outside of the range [0,1] are clamped.
-        public float BrushSize01
-        {
-            get
-            {
-                float min = _FromRadius(m_BrushSizeRange.x);
-                float max = _FromRadius(m_BrushSizeRange.y);
-                return Mathf.InverseLerp(min, max, _FromRadius(BrushSizeAbsolute));
-            }
-            set
-            {
-                float min = _FromRadius(m_BrushSizeRange.x);
-                float max = _FromRadius(m_BrushSizeRange.y);
-                BrushSizeAbsolute = _ToRadius(Mathf.Lerp(min, max, Mathf.Clamp01(value)));
-            }
-        }
-
-        /// The brush size, in absolute room space units.
-        /// On get, values are raw and may be outside the brush's desired range.
-        /// On set, values outside the brush's nominal range are clamped.
-        public float BrushSizeAbsolute
-        {
-            get => m_CurrentBrushSize;
-            set => _SetBrushSizeAbsolute(Mathf.Clamp(value, m_BrushSizeRange.x, m_BrushSizeRange.y));
-        }
-
-        // ---- Unity events
+        public Pointer Core { get; } = new Pointer();
 
         void Awake()
         {
-            m_ControlPoints = new List<ControlPoint>();
-            m_CurrentBrushSize = 1.0f;
-            m_BrushSizeRange.x = 1.0f;
-            m_BrushSizeRange.y = 2.0f;
-            m_CurrentPressure = 1.0f;
+            Core.Initialize();
+            SyncToCore();
+            SyncFromCore();
         }
 
         void Update()
         {
-            if (DrawingEnabled && !m_WasDrawingEnabled)
-            {
-                // Drawing just got enabled, so we need to create a new line.
-                // This is a no-op if the current line is already set.
-                CreateNewLine(m_Canvas, TrTransform.FromLocalTransform(transform));
-            }
-            else if (DrawingEnabled && m_WasDrawingEnabled)
-            {
-                UpdateLineFromObject();
-            }
-            else if (!DrawingEnabled && m_WasDrawingEnabled)
-            {
-                DetachLine(false);
-            }
-            m_WasDrawingEnabled = DrawingEnabled;
+            SyncToCore();
+            Core.Tick(transform);
+            SyncFromCore();
         }
 
-        /// Returns xf_RS, relative to the passed line transform.
-        /// Applies m_LineDepth and ignores xf_RS.scale
-        /// TODO: see above.
-        TrTransform GetTransformForLine(Transform line, TrTransform xf_RS)
+        void SyncToCore()
         {
-            var xfRoomFromLine = Coords.AsRoom[line];
-            xf_RS.translation += xf_RS.forward;
-            xf_RS.scale = 1;
-            return TrTransform.InvMul(xfRoomFromLine, xf_RS);
+            Core.DrawingEnabled = DrawingEnabled;
+            Core.Canvas = Canvas;
+            Core.m_CurrentColor = m_CurrentColor;
+            Core.m_CurrentBrush = m_CurrentBrush;
+            Core.m_CurrentBrushSize = m_CurrentBrushSize;
+            Core.m_CurrentPressure = m_CurrentPressure;
         }
 
-        /// Non-playback case:
-        /// - Update the stroke based on the object's position.
-        /// - Save off control points
-        /// - Play audio.
-        public void UpdateLineFromObject()
+        void SyncFromCore()
         {
-            if (m_CurrentLine == null) return;
-            var xf_LS = GetTransformForLine(m_CurrentLine.transform, Coords.AsRoom[transform]);
-
-            bool bQuadCreated = m_CurrentLine.UpdatePosition_LS(xf_LS, m_CurrentPressure);
-
-            // TODO: let brush take care of storing control points, not us
-            SetControlPoint(xf_LS, isKeeper: bQuadCreated);
-            UpdateLineVisuals();
-        }
-
-        /// Playback case:
-        /// - Update stroke based on the passed transform (in local coordinates)
-        /// - Do _not_ apply any normal adjustment; it's baked into the control point
-        /// - Do not update the mesh
-        /// TODO: replace with a bulk-ControlPoint API
-        public void UpdateLineFromControlPoint(ControlPoint cp)
-        {
-            float scale = m_CurrentLine.StrokeScale;
-            m_CurrentLine.UpdatePosition_LS(
-                TrTransform.TRS(cp.m_Pos, cp.m_Orient, scale), cp.m_Pressure);
-        }
-
-        /// Bulk control point addition
-        public void UpdateLineFromStroke(Stroke stroke)
-        {
-            float scale = m_CurrentLine.StrokeScale;
-            foreach (var cp in stroke.m_ControlPoints.Where((x, i) => !stroke.m_ControlPointsToDrop[i]))
-            {
-                m_CurrentLine.UpdatePosition_LS(TrTransform.TRS(cp.m_Pos, cp.m_Orient, scale), cp.m_Pressure);
-            }
-        }
-
-        public void UpdateLineVisuals()
-        {
-            m_CurrentLine.ApplyChangesToVisuals();
-        }
-
-        void _SetBrushSizeAbsolute(float value)
-        {
-            m_CurrentBrushSize = value;
-        }
-
-        /// Pass a Canvas parent, and a transform in that canvas's space.
-        /// If overrideDesc passed, use that for the visuals -- m_CurrentBrush does not change.
-        public void CreateNewLine(CanvasScript canvas, TrTransform xf_CS, BrushDescriptor overrideDesc = null)
-        {
-            // If straightedge is enabled, we may have a minimum size requirement.
-            // Initialize parametric stroke creator for our type of straightedge.
-            // Maybe change the brush to a proxy brush.
-            BrushDescriptor desc = overrideDesc != null ? overrideDesc : m_CurrentBrush;
-
-            m_CurrentLine = BaseBrushScript.Create(
-                canvas.transform, xf_CS,
-                desc, m_CurrentColor, m_CurrentBrushSize);
-        }
-
-        /// Like BeginLineFromMemory + EndLineFromMemory
-        /// To help catch bugs in higher-level stroke code, it is considered
-        /// an error unless the stroke is in state NotCreated.
-        public void RecreateLineFromMemory(Stroke stroke)
-        {
-            if (stroke.m_Type != Stroke.Type.NotCreated)
-            {
-                throw new InvalidOperationException();
-            }
-            if (BeginLineFromMemory(stroke, stroke.Canvas) == null)
-            {
-                // Unclear why it would have failed, but okay.
-                // I guess we keep the old version?
-                Debug.LogError("Unexpected error recreating line");
-                return;
-            }
-
-            UpdateLineFromStroke(stroke);
-
-            // It's kind of warty that this needs to happen; brushes should probably track
-            // the mesh-dirty state and flush it in Finalize().
-            // TODO: Check if this is still necessary now that QuadStripBrushStretchUV
-            // flushes pending geometry changes in Finalize*Brush()
-            m_CurrentLine.ApplyChangesToVisuals();
-
-            // Copy in new contents
-            {
-                m_CurrentLine.FinalizeSolitaryBrush();
-
-                stroke.m_Type = Stroke.Type.BrushStroke;
-                stroke.m_IntendedCanvas = null;
-                stroke.m_Object = m_CurrentLine.gameObject;
-                stroke.m_Object.GetComponent<BaseBrushScript>().Stroke = stroke;
-            }
-
-            m_CurrentLine = null;
-        }
-
-        public GameObject BeginLineFromMemory(Stroke stroke, CanvasScript canvas)
-        {
-            BrushDescriptor rBrush = BrushCatalog.GetBrush(stroke.m_BrushGuid);
-            if (rBrush == null)
-            {
-                // Ignore stroke
-                return null;
-            }
-
-            var cp0 = stroke.m_ControlPoints[0];
-            var xf_CS = TrTransform.TRS(cp0.m_Pos, cp0.m_Orient, stroke.m_BrushScale);
-            var xf_RS = canvas.Pose * xf_CS;
-
-            // This transform used to be incorrect, but we didn't notice.
-            // That implies this isn't necessary?
-            transform.position = xf_RS.translation;
-            transform.rotation = xf_RS.rotation;
-
-            m_CurrentBrush = rBrush;
-            m_CurrentBrushSize = stroke.m_BrushSize;
-            m_CurrentColor = stroke.m_Color;
-            CreateNewLine(canvas, xf_CS);
-            m_CurrentLine.SetIsLoading();
-            m_CurrentLine.RandomSeed = stroke.m_Seed;
-
-            return m_CurrentLine.gameObject;
-        }
-
-        /// Record the tranform as a control point.
-        /// If the most-recent point is a keeper, append a new control point.
-        /// Otherwise, the most-recent point is a keeper, and will be overwritten.
-        ///
-        /// The parameter "keep" specifies whether the newly-written point is a keeper.
-        ///
-        /// The current pointer is /not/ queried to get the transform of the new
-        /// control point. Instead, caller is responsible for passing in the same
-        /// xf that was passed to line.UpdatePosition_LS()
-        public void SetControlPoint(TrTransform lastSpawnXf_LS, bool isKeeper)
-        {
-            ControlPoint rControlPoint;
-            rControlPoint.m_Pos = lastSpawnXf_LS.translation;
-            rControlPoint.m_Orient = lastSpawnXf_LS.rotation;
-            rControlPoint.m_Pressure = m_CurrentPressure;
-            rControlPoint.m_TimestampMs = (uint)(App.CurrentSketchTime * 1000);
-
-            if (m_ControlPoints.Count == 0 || m_LastControlPointIsKeeper)
-            {
-                m_ControlPoints.Add(rControlPoint);
-            }
-            else
-            {
-                m_ControlPoints[m_ControlPoints.Count - 1] = rControlPoint;
-            }
-
-            m_LastControlPointIsKeeper = isKeeper;
-        }
-
-
-        // During playback, rMemoryObjectForPlayback is non-null, and strokeFlags should not be passed.
-        // otherwise, rMemoryObjectForPlayback is null, and strokeFlags should be valid.
-        // When non-null, rMemoryObjectForPlayback corresponds to the current line.
-        public void DetachLine(bool bDiscard)
-        {
-            if (bDiscard)
-            {
-                m_CurrentLine.DestroyMesh();
-                Destroy(m_CurrentLine.gameObject);
-            }
-            else
-            {
-                //copy master brush over to current line
-                m_CurrentLine.FinalizeSolitaryBrush();
-            }
-            m_CurrentLine = null;
+            DrawingEnabled = Core.DrawingEnabled;
+            Canvas = Core.Canvas;
+            m_CurrentColor = Core.m_CurrentColor;
+            m_CurrentBrush = Core.m_CurrentBrush;
+            m_CurrentBrushSize = Core.m_CurrentBrushSize;
+            m_CurrentPressure = Core.m_CurrentPressure;
         }
     }
-} // namespace TiltBrush
+}
+

--- a/Assets/Scripts/Stroke.cs
+++ b/Assets/Scripts/Stroke.cs
@@ -144,7 +144,7 @@ namespace TiltBrush
                     LeftTransformControlPoints(leftTransform.Value, absoluteScale);
                 }
 
-                pointer.RecreateLineFromMemory(this);
+                pointer.Core.RecreateLineFromMemory(this, pointer.transform);
             }
             else if (canvas != null)
             {
@@ -241,12 +241,12 @@ namespace TiltBrush
             }
 
             // Invariant is:
-            //   newCanvas.Pose * newCP = prevCanvas.Pose * prevCP
+            //   newCanvas.Core.Pose * newCP = prevCanvas.Core.Pose * prevCP
             // Solve for newCp:
-            //   newCP = (newCanvas.Pose.inverse * prevCanvas.Pose) * prevCP
-            TrTransform leftTransformValue = leftTransform ?? canvas.Pose.inverse * prevCanvas.Pose;
+            //   newCP = (newCanvas.Core.Pose.inverse * prevCanvas.Core.Pose) * prevCP
+            TrTransform leftTransformValue = leftTransform ?? canvas.Core.Pose.inverse * prevCanvas.Core.Pose;
             bool bWasTransformed = leftTransform.HasValue &&
-                !TrTransform.Approximately(prevCanvas.Pose, leftTransform.Value);
+                !TrTransform.Approximately(prevCanvas.Core.Pose, leftTransform.Value);
             if (m_Type == Type.NotCreated || !bWasTransformed)
             {
                 SetParent(canvas);
@@ -266,7 +266,7 @@ namespace TiltBrush
                     // PointerManager's pointer management is a complete mess.
                     // "5" is the most-likely to be unused. It's terrible that this
                     // needs to go through a pointer.
-                    pointer.RecreateLineFromMemory(this);
+                    pointer.Core.RecreateLineFromMemory(this, pointer.transform);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add AGENTS guidelines and Unity independence plan
- move sketch timing to new `AppCore` and keep `App` as thin wrapper
- wrap canvas logic in standalone `Canvas` class with `CanvasScript` delegate
- extract pointer functionality to non-MonoBehaviour `Pointer` with `PointerScript` stub
- preserve serialized pointer fields in stub and alias `UnityEngine.Object`
- slim MonoBehaviour stubs to only serialized data and core delegation
- route stroke recreation and canvas pose lookups through core components
- move brush undo clone logic into static `BaseBrush` helper

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c79ece0c83319130550bb3c170be